### PR TITLE
feat(orders): delete row + merge orders (with macOS ad-hoc signing)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ jobs:
 
       - name: Build Tauri app
         run: npm run tauri build -- --bundles ${{ matrix.bundles }}
+        env:
+          # Ad-hoc sign the macOS .app so Gatekeeper stops reporting the
+          # bundle as "damaged" after download. First launch still needs
+          # right-click → Open once (no Developer ID). Ignored on Windows.
+          APPLE_SIGNING_IDENTITY: '-'
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,34 @@ jobs:
           # right-click → Open once (no Developer ID). Ignored on Windows.
           APPLE_SIGNING_IDENTITY: '-'
 
+      - name: Inject install README into DMG
+        if: matrix.os == 'macos-latest'
+        # Tauri's bundler doesn't have a hook for adding files next to the
+        # .app inside the DMG, so we post-process: convert the built DMG to
+        # read-write, mount it on a fixed mount point (so the volume's space
+        # in its name doesn't trip up shell parsing), drop the file in,
+        # then recompress.
+        run: |
+          set -euo pipefail
+          SRC_DMG=$(ls src-tauri/target/release/bundle/dmg/*.dmg | head -1)
+          RW_DMG="${SRC_DMG%.dmg}-rw.dmg"
+          MOUNT="/tmp/dmg-mount"
+
+          hdiutil convert "$SRC_DMG" -format UDRW -o "$RW_DMG"
+          # Add slack space so the new file fits — the freshly-built DMG is
+          # sized just-fit and a copy into a full volume errors out.
+          hdiutil resize -size 300m "$RW_DMG"
+
+          mkdir -p "$MOUNT"
+          hdiutil attach "$RW_DMG" -noverify -nobrowse -mountpoint "$MOUNT"
+          cp "installers/macos/READ ME FIRST.txt" "$MOUNT/"
+          hdiutil detach "$MOUNT"
+
+          # Repack as compressed read-only, then swap the original.
+          hdiutil convert "$RW_DMG" -format UDZO -o "${SRC_DMG}.new.dmg"
+          mv -f "${SRC_DMG}.new.dmg" "$SRC_DMG"
+          rm -f "$RW_DMG"
+
       - name: Upload bundle
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,75 @@
-# mini-pos
-Create mini-pos to print receipt into thermal printer using Python.
+# Granny's POS
 
-## Need to install python3.8
+A small point-of-sale app for printing receipts to a thermal printer, with Google Sheets sync and PromptPay QR codes.
 
-1. Download installer from [python-380](https://www.python.org/downloads/release/python-380/)
-2. Default path is C:\Users\[user_name]\AppData\Local\Programs\Python\Python38
+## Download
 
-## Running application
+Grab the latest installer from the **[Releases page](https://github.com/panuphanch/mini-pos/releases/latest)**:
 
-1. Create virtual environment `C:\Users\[user_name]\AppData\Local\Programs\Python\Python38\python.exe -m venv venv`
-2. Will create `venv` as new folder
-3. Activate virtual environment `venv\Scripts\active`
-4. pip install -r requirement.txt
-5. python main.py
+- **macOS** → download the file ending in `.dmg`
+- **Windows** → download the file ending in `.msi`
 
-## Create executable
+## Install on macOS
 
-1. Activate virtual environment
-2. Run `python -m eel main.py web --add-data "_internal/*;."`
+1. **Open the `.dmg` file** you downloaded.
+2. **Drag _Granny's POS_ into the _Applications_ folder.**
+3. **Eject the disk image** (right-click the disk icon on your desktop → Eject).
+
+### First time you open it
+
+The first time only, macOS will block the app because it isn't from the App Store. This is normal — just follow these steps once:
+
+1. Open **Applications** and double-click _Granny's POS_.
+2. You'll see this message:
+
+   > _"Granny's POS" Not Opened — Apple could not verify "Granny's POS" is free of malware…_
+
+   Click **Done**.
+
+3. Open **System Settings** (the gear icon in the Dock, or Apple menu → System Settings).
+4. Click **Privacy & Security** in the sidebar.
+5. **Scroll all the way down** to the **Security** section. You'll see a line that says:
+
+   > _"Granny's POS" was blocked to protect your Mac._
+
+   Click the **Open Anyway** button next to it.
+
+6. Enter your Mac password if asked.
+7. Double-click _Granny's POS_ in Applications again. A new dialog appears — this time with an **Open** button. Click **Open**.
+
+That's it. From now on, double-clicking the app just opens it normally.
+
+## Install on Windows
+
+1. **Double-click the `.msi` file** you downloaded.
+2. Follow the installer (just keep clicking Next).
+3. _Granny's POS_ will appear in the Start menu.
+
+If Windows shows a blue **"Windows protected your PC"** screen:
+
+1. Click **More info**.
+2. Click **Run anyway**.
+
+This only happens the first time.
+
+## First-time setup inside the app
+
+1. Open _Granny's POS_.
+2. Go to the **Settings** tab.
+3. Fill in:
+   - **Shop name, phone, LINE**
+   - **Printer IP address** (you can find this in your printer's network menu)
+   - **PromptPay number** (phone number or ID card)
+   - **Google Sheet ID** + the service account JSON file (your husband or developer will set this up for you).
+4. Click **Save**.
+5. Go to the **Sync** tab and tap **Sync this week** to pull orders from the Google Sheet.
+
+## Day-to-day
+
+- **Orders** tab → see this week's orders, print receipts, mark items, merge rows.
+- **Sync** tab → pull the latest from Google Sheets after your wife adds new orders.
+- **Settings** tab → change printer / shop info anytime.
+
+## Need help?
+
+Open an issue on the [GitHub repo](https://github.com/panuphanch/mini-pos/issues) or ask the person who set this up for you.

--- a/docs/brainstorms/2026-05-23-duplicate-rows.html
+++ b/docs/brainstorms/2026-05-23-duplicate-rows.html
@@ -1,0 +1,579 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Brainstorm — Handling duplicate-row customers in Orders</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --bg: #fafaf7;
+    --card: #ffffff;
+    --ink: #1a1a1a;
+    --muted: #6b6b6b;
+    --line: #e5e5e0;
+    --accent: #2563eb;
+    --accent-soft: #eff6ff;
+    --good: #15803d;
+    --good-soft: #ecfdf5;
+    --warn: #b45309;
+    --warn-soft: #fef3c7;
+    --bad: #b91c1c;
+    --bad-soft: #fef2f2;
+    --pick: #7c2d12;
+    --pick-soft: #fff7ed;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 24px 80px; }
+  header.page {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 20px;
+    margin-bottom: 32px;
+  }
+  header.page .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 11px;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  header.page h1 {
+    margin: 6px 0 8px;
+    font-size: 28px;
+    letter-spacing: -0.01em;
+  }
+  header.page p { margin: 0; color: var(--muted); max-width: 70ch; }
+
+  h2 { font-size: 18px; margin: 40px 0 12px; letter-spacing: -0.005em; }
+  h3 { font-size: 15px; margin: 0 0 6px; }
+
+  .lede {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px 18px;
+  }
+
+  /* Use-case cards */
+  .cases { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 12px; }
+  .case {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 16px;
+  }
+  .case .tag {
+    display: inline-block; font-size: 11px; font-weight: 600;
+    padding: 2px 8px; border-radius: 999px; margin-bottom: 6px;
+  }
+  .case .freq { font-size: 12px; color: var(--muted); margin-top: 8px; }
+  .tag-primary { background: var(--accent-soft); color: var(--accent); }
+  .tag-edge    { background: var(--warn-soft); color: var(--warn); }
+  .tag-mistake { background: var(--bad-soft);  color: var(--bad);  }
+
+  /* Mocked POS list row */
+  .mock {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    font-size: 13px;
+  }
+  .mock-head, .mock-row {
+    display: grid;
+    grid-template-columns: 28px 90px 1fr 100px 90px 110px;
+    gap: 10px;
+    padding: 9px 12px;
+    align-items: center;
+  }
+  .mock-head {
+    background: #f5f5f0;
+    color: var(--muted);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    border-bottom: 1px solid var(--line);
+  }
+  .mock-row { border-bottom: 1px solid var(--line); }
+  .mock-row:last-child { border-bottom: 0; }
+  .mock-row.selected { background: var(--accent-soft); }
+  .mock-row.grouped  { background: #fffbeb; }
+  .mock-row .num { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .mock-row .total { text-align: right; font-variant-numeric: tabular-nums; }
+  .pill {
+    font-size: 10px; padding: 1px 6px; border-radius: 999px;
+    background: #f1f1ec; color: var(--muted);
+  }
+  .pill.group { background: var(--warn-soft); color: var(--warn); }
+  .btn {
+    background: var(--accent); color: white; border: 0;
+    padding: 4px 10px; border-radius: 6px; font-size: 12px;
+    font-weight: 500;
+  }
+  .btn.ghost  { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+  .btn.danger { background: var(--bad); }
+
+  /* Option cards */
+  .options { display: grid; gap: 18px; }
+  .option {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  .option.picked { border-color: var(--pick); box-shadow: 0 0 0 3px var(--pick-soft); }
+  .option header {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--line);
+    display: flex; align-items: baseline; gap: 12px;
+    flex-wrap: wrap;
+  }
+  .option header h3 { margin: 0; font-size: 16px; }
+  .option header .label {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--muted);
+  }
+  .option header .pick {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--pick);
+    background: var(--pick-soft); padding: 2px 8px; border-radius: 999px;
+  }
+  .option header .summary { color: var(--muted); font-size: 13px; flex: 1 1 100%; }
+  .option .body { padding: 16px 18px; }
+  .option .twocol {
+    display: grid; grid-template-columns: 1.4fr 1fr; gap: 18px;
+  }
+  @media (max-width: 720px) {
+    .option .twocol { grid-template-columns: 1fr; }
+    .cases { grid-template-columns: 1fr; }
+    .mock-head, .mock-row { grid-template-columns: 80px 1fr 80px; }
+    .mock-head .col-hide, .mock-row .col-hide { display: none; }
+  }
+
+  .pros, .cons {
+    margin: 0; padding: 10px 12px;
+    border-radius: 8px;
+    list-style: none;
+    font-size: 13px;
+  }
+  .pros { background: var(--good-soft); }
+  .cons { background: var(--bad-soft); }
+  .pros li::before { content: "✓ "; color: var(--good); font-weight: 700; }
+  .cons li::before { content: "✗ "; color: var(--bad); font-weight: 700; }
+  .pros li, .cons li { padding: 2px 0; }
+
+  /* Compare table */
+  table.compare {
+    width: 100%; border-collapse: collapse; background: var(--card);
+    border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+    font-size: 13px;
+  }
+  table.compare th, table.compare td {
+    padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left;
+    vertical-align: top;
+  }
+  table.compare th { background: #f5f5f0; font-weight: 600; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  table.compare tr:last-child td { border-bottom: 0; }
+  table.compare .verdict-yes  { color: var(--good); font-weight: 600; }
+  table.compare .verdict-no   { color: var(--bad);  font-weight: 600; }
+  table.compare .verdict-meh  { color: var(--warn); font-weight: 600; }
+
+  details {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 8px 14px; margin-top: 12px;
+  }
+  details summary { cursor: pointer; font-weight: 600; }
+  details[open] { padding-bottom: 14px; }
+
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-soft);
+    padding: 10px 14px;
+    border-radius: 0 8px 8px 0;
+    margin: 12px 0;
+    font-size: 13px;
+  }
+  .callout.warn { border-color: var(--warn); background: var(--warn-soft); }
+
+  code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="page">
+  <div class="eyebrow">Brainstorm · 2026-05-23</div>
+  <h1>Handling duplicate-customer rows in the Orders list</h1>
+  <p>
+    Your wife sometimes splits one customer across multiple sheet rows (e.g. <strong>K.Ing</strong>:
+    one row per cake, but she pays for both). Today each row becomes a separate order with its own
+    receipt and QR. We need a way to <em>combine</em> these at checkout — and to <em>delete</em>
+    obvious duplicates — without breaking the sync model.
+  </p>
+</header>
+
+<section>
+  <h2>The use cases we're solving for</h2>
+  <div class="cases">
+    <div class="case">
+      <span class="tag tag-primary">Primary</span>
+      <h3>Same person, split rows on purpose</h3>
+      <div>Wife wrote 2 rows for K.Ing so the kitchen prepares two distinct cakes. K.Ing pays once and wants <strong>one receipt</strong> with both items.</div>
+      <div class="freq">Happens regularly. This is the case you described.</div>
+    </div>
+    <div class="case">
+      <span class="tag tag-edge">Edge</span>
+      <h3>Ordered together but separate receipts</h3>
+      <div>A friend orders through K.Ing but wants their own receipt + QR. Two rows that should stay two orders, but be handed over as a pair.</div>
+      <div class="freq">Occasional.</div>
+    </div>
+    <div class="case">
+      <span class="tag tag-mistake">Mistake</span>
+      <h3>Accidental duplicate</h3>
+      <div>Wife typed the same order twice, or a row is empty / wrong. Should just disappear.</div>
+      <div class="freq">Rare but disruptive.</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>The constraint that shapes everything</h2>
+  <div class="lede">
+    The Google Sheet is the <strong>source of truth</strong>. Sync upserts by
+    <code>(source_tab, source_row)</code>. Anything we do in-app to combine or hide rows has to
+    survive the next sync — otherwise the merge will silently un-merge itself when she taps
+    Re-sync. You already have the two primitives we need for this:
+    <code>sync_locked</code> (sync ignores the row) and soft-delete (<code>deleted_at</code>).
+  </div>
+</section>
+
+<section>
+  <h2>Four approaches worth considering</h2>
+  <div class="options">
+
+    <!-- Option A -->
+    <article class="option">
+      <header>
+        <span class="label">Option A</span>
+        <h3>"Print together" — combine at print time, no DB merge</h3>
+        <div class="summary">
+          Cashier ticks 2+ rows in the list, taps <em>Print together</em>. We render one receipt
+          with all line items summed and one QR for the combined total. The orders stay separate
+          in the database; nothing is locked, deleted, or merged.
+        </div>
+      </header>
+      <div class="body">
+        <div class="twocol">
+          <div>
+            <div class="mock" aria-label="Mock list with two rows selected">
+              <div class="mock-head">
+                <div>✓</div><div>Order #</div><div>Customer</div><div class="col-hide">Items</div><div class="col-hide total">Total</div><div></div>
+              </div>
+              <div class="mock-row selected">
+                <div>☑︎</div><div class="num">Order_30-04</div><div>K.Ing</div><div class="col-hide">1× Choc Lava</div><div class="col-hide total">฿180</div><div></div>
+              </div>
+              <div class="mock-row selected">
+                <div>☑︎</div><div class="num">Order_30-05</div><div>K.Ing</div><div class="col-hide">1× Matcha Roll</div><div class="col-hide total">฿220</div><div></div>
+              </div>
+              <div class="mock-row">
+                <div>☐</div><div class="num">Order_30-06</div><div>P.Som</div><div class="col-hide">2× Brownie</div><div class="col-hide total">฿160</div><div><button class="btn ghost">Print</button></div>
+              </div>
+            </div>
+            <div style="margin-top:8px; display:flex; gap:6px; align-items:center; font-size:12px; color:var(--muted);">
+              When ≥2 rows are selected → toolbar shows <button class="btn" style="margin:0 4px;">Print together (฿400)</button>
+            </div>
+          </div>
+          <div>
+            <ul class="pros">
+              <li>Zero schema change — nothing to migrate.</li>
+              <li>100% safe with sync: the rows are untouched.</li>
+              <li>Reversible by definition (nothing to undo).</li>
+              <li>Handles 2, 3, or N rows the same way.</li>
+              <li>Edge case "two friends, hand over together" is solved by a sibling button: <em>Print separately, side-by-side</em>.</li>
+            </ul>
+            <ul class="cons" style="margin-top:8px;">
+              <li>Orders still show as two rows in the list — visual clutter remains.</li>
+              <li>"Printed" state is per-row; we have to decide whether the combined print marks both as printed (yes, probably).</li>
+              <li>Reports/analytics later will count two orders, not one.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Option B -->
+    <article class="option picked">
+      <header>
+        <span class="label">Option B</span>
+        <h3>True merge — fold rows into one master order, lock the sources</h3>
+        <span class="pick">Recommended</span>
+        <div class="summary">
+          Pick 2+ rows → <em>Merge</em>. One row becomes the master; the others contribute their
+          items into it, then are soft-deleted and <code>sync_locked</code>. Re-sync ignores them.
+          The master shows all items, one total, one QR. Un-merge is a separate action.
+        </div>
+      </header>
+      <div class="body">
+        <div class="twocol">
+          <div>
+            <div class="mock" aria-label="Mock list after merge">
+              <div class="mock-head">
+                <div></div><div>Order #</div><div>Customer</div><div class="col-hide">Items</div><div class="col-hide total">Total</div><div></div>
+              </div>
+              <div class="mock-row">
+                <div></div>
+                <div class="num">Order_30-04 <span class="pill group">merged ×2</span></div>
+                <div>K.Ing</div>
+                <div class="col-hide">Choc Lava, Matcha Roll</div>
+                <div class="col-hide total">฿400</div>
+                <div><button class="btn">Print</button></div>
+              </div>
+              <div class="mock-row">
+                <div></div><div class="num">Order_30-06</div><div>P.Som</div><div class="col-hide">2× Brownie</div><div class="col-hide total">฿160</div><div><button class="btn ghost">Print</button></div>
+              </div>
+            </div>
+            <div style="margin-top:8px; font-size:12px; color:var(--muted);">
+              Source rows (Order_30-05) are hidden but reachable under <em>Show removed</em> with
+              a <span class="pill">merged into 04</span> badge.
+            </div>
+          </div>
+          <div>
+            <ul class="pros">
+              <li>The Orders list visually matches reality — one customer, one row.</li>
+              <li>Reports & "Reprint" act on the real combined order.</li>
+              <li>Reuses what's already there: <code>sync_locked</code>, <code>deleted_at</code>.</li>
+              <li>Un-merge is feasible because we keep the original line items tagged with their <code>source_row</code>.</li>
+            </ul>
+            <ul class="cons" style="margin-top:8px;">
+              <li>Requires a small schema addition (<code>merged_into_id</code> on order).</li>
+              <li>If wife later <em>edits</em> the merged-away row in the sheet, the edit is silently ignored (because the row is locked). We mitigate with a sync warning: <em>"Order_30-05 changed in the sheet but is merged — review?"</em></li>
+              <li>Slightly more code than Option A.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Option C -->
+    <article class="option">
+      <header>
+        <span class="label">Option C</span>
+        <h3>Group — link rows without merging them</h3>
+        <div class="summary">
+          Select 2+ rows → <em>Group as one payment</em>. The list shows them as a stacked card
+          with a single "Print group" button, but each row is still an independent order under
+          the hood. Best when intent is ambiguous (sometimes one receipt, sometimes two).
+        </div>
+      </header>
+      <div class="body">
+        <div class="twocol">
+          <div>
+            <div class="mock">
+              <div class="mock-head">
+                <div></div><div>Order #</div><div>Customer</div><div class="col-hide">Items</div><div class="col-hide total">Total</div><div></div>
+              </div>
+              <div class="mock-row grouped">
+                <div>▾</div>
+                <div class="num">Group A · 2 orders</div>
+                <div>K.Ing</div>
+                <div class="col-hide">Choc Lava, Matcha Roll</div>
+                <div class="col-hide total">฿400</div>
+                <div><button class="btn">Print group</button></div>
+              </div>
+              <div class="mock-row" style="background:#fffdf6;">
+                <div></div><div class="num">  ↳ Order_30-04</div><div>K.Ing</div><div class="col-hide">Choc Lava</div><div class="col-hide total">฿180</div><div><button class="btn ghost">Print only</button></div>
+              </div>
+              <div class="mock-row" style="background:#fffdf6;">
+                <div></div><div class="num">  ↳ Order_30-05</div><div>K.Ing</div><div class="col-hide">Matcha Roll</div><div class="col-hide total">฿220</div><div><button class="btn ghost">Print only</button></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <ul class="pros">
+              <li>Doesn't destroy data — both intents (one receipt OR two together) supported.</li>
+              <li>Edits from the sheet still flow into each child order.</li>
+              <li>Models the friend-orders-through-K.Ing case naturally.</li>
+            </ul>
+            <ul class="cons" style="margin-top:8px;">
+              <li>New concept ("group") for the cashier to learn.</li>
+              <li>Most complex UI of the four — expand/collapse, group vs row actions.</li>
+              <li>Needs its own table (<code>order_group</code>) — biggest schema change.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Option D -->
+    <article class="option">
+      <header>
+        <span class="label">Option D</span>
+        <h3>Delete only — soft-delete the unwanted row, edit the other</h3>
+        <div class="summary">
+          Add a delete (soft-remove) button to each row, plus the existing <em>Edit order</em>
+          dialog to add the missing item into the surviving order. Doesn't really solve K.Ing on
+          its own; only solves the duplicate-mistake case.
+        </div>
+      </header>
+      <div class="body">
+        <ul class="pros">
+          <li>Smallest possible change — basically one new button.</li>
+          <li>Soft-delete already exists in the schema.</li>
+        </ul>
+        <ul class="cons" style="margin-top:8px;">
+          <li>For K.Ing it's a 3-step manual dance: delete row B, open row A, add B's items, save. Easy to mess up.</li>
+          <li>Loses the audit trail of what was actually written on the sheet.</li>
+        </ul>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<section>
+  <h2>Side-by-side</h2>
+  <table class="compare">
+    <thead>
+      <tr>
+        <th>Capability</th>
+        <th>A · Print together</th>
+        <th>B · Merge (rec.)</th>
+        <th>C · Group</th>
+        <th>D · Delete only</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Solves K.Ing case</td>
+        <td class="verdict-yes">Yes</td>
+        <td class="verdict-yes">Yes</td>
+        <td class="verdict-yes">Yes</td>
+        <td class="verdict-meh">Manual</td>
+      </tr>
+      <tr>
+        <td>Solves "friend, separate receipts but together"</td>
+        <td class="verdict-yes">Yes (sibling button)</td>
+        <td class="verdict-no">No</td>
+        <td class="verdict-yes">Yes</td>
+        <td class="verdict-no">No</td>
+      </tr>
+      <tr>
+        <td>Solves accidental duplicate</td>
+        <td class="verdict-no">No (still need delete)</td>
+        <td class="verdict-yes">Yes (merge "into nothing" = delete)</td>
+        <td class="verdict-no">No (still need delete)</td>
+        <td class="verdict-yes">Yes</td>
+      </tr>
+      <tr>
+        <td>Schema change</td>
+        <td class="verdict-yes">None</td>
+        <td class="verdict-meh">+1 column</td>
+        <td class="verdict-no">+1 table</td>
+        <td class="verdict-yes">None</td>
+      </tr>
+      <tr>
+        <td>Survives re-sync</td>
+        <td class="verdict-yes">Trivially</td>
+        <td class="verdict-yes">Via sync_locked</td>
+        <td class="verdict-yes">Children still sync</td>
+        <td class="verdict-meh">Need lock too</td>
+      </tr>
+      <tr>
+        <td>Reversible</td>
+        <td class="verdict-yes">No-op to undo</td>
+        <td class="verdict-yes">Un-merge action</td>
+        <td class="verdict-yes">Un-group action</td>
+        <td class="verdict-yes">Show removed</td>
+      </tr>
+      <tr>
+        <td>List visually deduplicated</td>
+        <td class="verdict-no">No</td>
+        <td class="verdict-yes">Yes</td>
+        <td class="verdict-meh">Grouped</td>
+        <td class="verdict-yes">Yes (after delete)</td>
+      </tr>
+      <tr>
+        <td>Implementation cost</td>
+        <td class="verdict-yes">Smallest</td>
+        <td class="verdict-meh">Medium</td>
+        <td class="verdict-no">Largest</td>
+        <td class="verdict-yes">Smallest</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2>My recommendation</h2>
+  <div class="callout">
+    <strong>Ship Option B (Merge) + a small Delete action, in that order.</strong>
+    <ol style="margin: 8px 0 0 20px; padding: 0;">
+      <li><strong>Delete first</strong> (½-day): one row, one button, soft-delete + <code>sync_locked</code>. Solves the mistake case immediately and gives you the lock primitive on its own.</li>
+      <li><strong>Merge next</strong> (1–2 days): builds on delete. Pick 2+ rows → master is the lowest <code>source_row</code> → items copy into master → others get <code>deleted_at</code> + <code>sync_locked</code> + <code>merged_into_id = master</code>. Un-merge reads <code>merged_into_id</code> and reverses it.</li>
+    </ol>
+    Option A is tempting for its simplicity, but it leaves the list cluttered and creates a weird split between "displayed order count" and "real order count" that gets worse as more rows pile up over a week.
+  </div>
+  <div class="callout">
+    <strong>Sync edge case — the smart way:</strong> instead of locking merged-away rows and
+    warning when they change, we tag every line item with the <code>source_row</code> it came
+    from. Sync stays transparent: when a merged row changes in the sheet, the engine replaces the
+    items tagged with that row inside the master and recomputes the total. Wife keeps editing the
+    sheet like normal — no extra steps after the initial merge. <code>sync_locked</code> only
+    fires if she edits the merged order <em>inside the app</em> (discount, delivery fee), at
+    which point sheet edits are ignored as today.
+  </div>
+</section>
+
+<section>
+  <h2>Decisions (2026-05-23)</h2>
+  <ol>
+    <li><strong>Different customer names on merge:</strong> lenient — allow it, but pop a
+        confirm: <em>"Merge P.Som's order into K.Ing's? She'll get one receipt under K.Ing's name."</em></li>
+    <li><strong>Master row deleted from sheet:</strong> remove its row-tagged items from master,
+        soft-delete the master if nothing's left. Surface a sync notice.</li>
+    <li><strong>Discount &amp; delivery fee:</strong> sum on merge. If wife wants them split per
+        row she just doesn't merge — the per-row receipt path already works.</li>
+    <li><strong>Un-merge:</strong> defer. Merge has a confirm dialog; accidents should be rare.
+        Add the button later if it becomes a real pain.</li>
+  </ol>
+</section>
+
+<section>
+  <h2>What I'd build, concretely</h2>
+  <details>
+    <summary>UI changes</summary>
+    <ul>
+      <li>Add a checkbox column to <code>OrdersPage</code>; selecting 2+ reveals a toolbar with <em>Merge</em> and <em>Delete</em>.</li>
+      <li>Each row gets a trash icon next to the existing edit icon (1 row = quick delete).</li>
+      <li>Merged orders show a <code>merged ×N</code> pill next to the order number. Detail panel lists which source rows contributed which items.</li>
+      <li>"Show removed" checkbox already exists — extend to also surface merged-away rows with a <em>merged into 04</em> badge and a <em>Restore / un-merge</em> button.</li>
+    </ul>
+  </details>
+  <details>
+    <summary>Backend changes</summary>
+    <ul>
+      <li>Schema: add <code>merged_into_id TEXT NULL REFERENCES "order"(id)</code> on <code>order</code>. Items keep their existing <code>source_row</code> via a new column on <code>order_item</code> (or denormalized on the order).</li>
+      <li>New Tauri commands: <code>orders_delete(id)</code>, <code>orders_merge(ids[])</code>, <code>orders_unmerge(id)</code>.</li>
+      <li>Sync engine: when iterating sheet rows, skip any with non-null <code>merged_into_id</code> but compare the sheet content against the snapshot; if changed, push a warning into the existing sync-warnings surface.</li>
+    </ul>
+  </details>
+  <details>
+    <summary>Testing</summary>
+    <ul>
+      <li>Merge of 2 rows → one order with combined items, others soft-deleted + locked.</li>
+      <li>Re-sync after merge: no resurrection.</li>
+      <li>Sheet edits a merged-away row → sync produces a warning, does not modify the master.</li>
+      <li>Un-merge → master loses the donated items, donor row comes back, lock cleared.</li>
+      <li>Delete-only path: soft delete + lock, "show removed" reveals it, restore works.</li>
+    </ul>
+  </details>
+</section>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-23-merge-orders.md
+++ b/docs/superpowers/plans/2026-05-23-merge-orders.md
@@ -1,0 +1,1805 @@
+# Merge Orders & Delete Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the cashier (a) soft-delete a duplicate row from the Orders list and (b) merge two or more rows for the same customer into a single receipt while still letting sheet edits flow into the merged result.
+
+**Architecture:** Two independent phases. Phase 1 adds a `delete_order` Tauri command and a trash icon in `OrdersPage`. Phase 2 adds a `merged_into_id` column on `"order"` and a `source_row` tag on `order_item` so the sync engine can refresh items per sheet row instead of per order. Merging re-parents the donor's items onto the master order and soft-deletes the donor; subsequent sheet edits to either row continue to flow into the master by matching items on `source_row`.
+
+**Tech Stack:** Rust (Tauri 2 + sqlx + SQLite), React + TypeScript + shadcn/ui, vitest, cargo test.
+
+**Spec:** [`docs/superpowers/specs/2026-05-23-merge-orders-design.md`](../specs/2026-05-23-merge-orders-design.md)
+
+---
+
+## Phase 1 — Delete a row
+
+### Task 1: Add `delete_order` DB function with tests
+
+**Files:**
+- Modify: `src-tauri/src/db/orders.rs` (append a function + tests near the existing `apply_order_edit`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `#[cfg(test)] mod tests` block in `src-tauri/src/db/orders.rs`:
+
+```rust
+#[tokio::test]
+async fn delete_order_soft_deletes_and_locks_against_resync() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+
+    // Insert via the normal sync path so the row mirrors a real sheet row.
+    let mut tx = pool.begin().await.unwrap();
+    let out = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None,
+        delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+
+    delete_order(&pool, &out.order_id).await.unwrap();
+
+    // Hidden by default
+    let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+    assert_eq!(alive.len(), 0);
+    // Visible under include_deleted
+    let all = list_by_tab(&pool, Some("Order_30"), true, 100).await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(all[0].deleted_at.is_some());
+    assert_eq!(all[0].sync_locked, 1);
+
+    // Re-syncing the same row must NOT resurrect it (sync_locked guards both
+    // upsert_from_source and soft_delete_missing_rows).
+    let mut tx = pool.begin().await.unwrap();
+    upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None,
+        delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+    assert_eq!(alive.len(), 0, "deleted+locked row must stay hidden after re-sync");
+}
+
+#[tokio::test]
+async fn delete_order_rejects_already_deleted() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let out = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    delete_order(&pool, &out.order_id).await.unwrap();
+    let err = delete_order(&pool, &out.order_id).await;
+    assert!(err.is_err(), "second delete should error");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `src-tauri/`:
+```bash
+cargo test --quiet --lib db::orders::tests::delete_order
+```
+Expected: compile error — `delete_order` is not defined.
+
+- [ ] **Step 3: Implement `delete_order`**
+
+Append to `src-tauri/src/db/orders.rs` just before the `#[cfg(test)]` block:
+
+```rust
+/// Soft-delete an order and lock it against re-sync.
+///
+/// Returns an error if the order doesn't exist, is already soft-deleted, or
+/// has been merged into another order (Phase 2). The lock is what stops the
+/// next `apply_sync` from inserting the row again.
+pub async fn delete_order(pool: &SqlitePool, order_id: &str) -> Result<(), sqlx::Error> {
+    let row: Option<(Option<String>,)> = sqlx::query_as(
+        r#"SELECT deleted_at FROM "order" WHERE id = ?"#,
+    )
+    .bind(order_id).fetch_optional(pool).await?;
+    let Some((deleted_at,)) = row else {
+        return Err(sqlx::Error::RowNotFound);
+    };
+    if deleted_at.is_some() {
+        return Err(sqlx::Error::Protocol(
+            format!("order {} is already deleted", order_id).into()
+        ));
+    }
+    let now = now_iso();
+    sqlx::query(
+        r#"UPDATE "order" SET deleted_at = ?, sync_locked = 1, updated_at = ?
+           WHERE id = ?"#,
+    )
+    .bind(&now).bind(&now).bind(order_id)
+    .execute(pool).await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test --quiet --lib db::orders::tests::delete_order
+```
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/db/orders.rs
+git commit -m "feat(orders): add delete_order to soft-delete + lock a row"
+```
+
+---
+
+### Task 2: Expose `delete_order` as a Tauri command
+
+**Files:**
+- Modify: `src-tauri/src/commands/orders.rs` (add command at end of file)
+- Modify: `src-tauri/src/lib.rs:30-45` (register in `invoke_handler`)
+
+- [ ] **Step 1: Add the command**
+
+Append to `src-tauri/src/commands/orders.rs`:
+
+```rust
+#[tauri::command]
+pub async fn delete_order(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<(), String> {
+    orders::delete_order(&state.db, &id).await.map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 2: Register the command**
+
+In `src-tauri/src/lib.rs`, add `commands::orders::delete_order,` to the `invoke_handler` list. The block should now contain (showing only the orders subsection):
+
+```rust
+            commands::orders::list_orders,
+            commands::orders::get_order,
+            commands::orders::print_order,
+            commands::orders::update_order,
+            commands::orders::delete_order,
+```
+
+- [ ] **Step 3: Verify the backend still builds**
+
+From `src-tauri/`:
+```bash
+cargo build --quiet
+```
+Expected: compiles with no warnings about an unused command.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/commands/orders.rs src-tauri/src/lib.rs
+git commit -m "feat(orders): expose delete_order Tauri command"
+```
+
+---
+
+### Task 3: Add `ordersApi.delete` on the frontend
+
+**Files:**
+- Modify: `src/lib/tauri.ts:44-56`
+
+- [ ] **Step 1: Add the API binding**
+
+In `src/lib/tauri.ts`, extend the `ordersApi` block so it reads:
+
+```ts
+export const ordersApi = {
+  list: (opts: { tab?: string; includeDeleted?: boolean; limit?: number } = {}) =>
+    invoke<OrderListRow[]>('list_orders', {
+      tab: opts.tab ?? null,
+      includeDeleted: opts.includeDeleted ?? false,
+      limit: opts.limit ?? 200,
+    }),
+  get: (id: string) => invoke<OrderDetail | null>('get_order', { id }),
+  print: (config: AppConfig, id: string) =>
+    invoke<string>('print_order', { config, id }),
+  update: (id: string, payload: OrderEditPayload) =>
+    invoke<void>('update_order', { id, payload }),
+  delete: (id: string) => invoke<void>('delete_order', { id }),
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+From the project root:
+```bash
+npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/tauri.ts
+git commit -m "feat(orders): ordersApi.delete binding"
+```
+
+---
+
+### Task 4: Trash icon + confirm dialog in OrdersPage
+
+**Files:**
+- Modify: `src/pages/OrdersPage.tsx` (add state, handler, button on each row; add Dialog import)
+
+- [ ] **Step 1: Add the delete state and handler near the existing edit state**
+
+In `src/pages/OrdersPage.tsx`, after the existing `editingLoading` state line (around line 44), add:
+
+```tsx
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deletingTarget, setDeletingTarget] = useState<OrderListRow | null>(null);
+
+  const confirmDelete = async () => {
+    if (!deletingTarget) return;
+    setDeletingId(deletingTarget.id);
+    try {
+      await ordersApi.delete(deletingTarget.id);
+      setDeletingTarget(null);
+      await fetchOrders();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+```
+
+- [ ] **Step 2: Add the `Trash2` icon import**
+
+In the top `lucide-react` import block of the same file, add `Trash2,` next to `PencilLine`:
+
+```tsx
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Lock,
+  MapPin,
+  PencilLine,
+  Printer,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
+```
+
+- [ ] **Step 3: Add Dialog imports**
+
+Below the existing `Select` imports, add:
+
+```tsx
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
+```
+
+- [ ] **Step 4: Wire the trash button into `OrderRow`**
+
+Extend the `OrderRowProps` interface to accept the delete callback:
+
+```tsx
+interface OrderRowProps {
+  row: OrderListRow;
+  isExpanded: boolean;
+  detail: OrderDetail | undefined;
+  printing: boolean;
+  editingLoading: boolean;
+  deleting: boolean;
+  onToggle: () => void;
+  onPrint: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+```
+
+Update the `OrderRow` function signature to destructure the new props and add the trash button. Replace the existing edit-button `<td>` block (around line 290–302) with this two-button block:
+
+```tsx
+        <td className="w-20 px-2 py-3 text-center">
+          {!removed && (
+            <div className="flex items-center justify-center gap-1">
+              <Button
+                variant="ghost"
+                size="iconSm"
+                aria-label="Edit order"
+                onClick={stopAndEdit}
+                disabled={editingLoading}
+              >
+                <PencilLine className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="iconSm"
+                aria-label="Delete order"
+                onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                disabled={deleting}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </td>
+```
+
+Update the matching `<th>` in the header row (around line 182) so the column is wider:
+
+```tsx
+                <th className="w-20 px-2 py-3 font-medium"></th>
+```
+
+- [ ] **Step 5: Pass the callback when rendering `OrderRow`**
+
+In the `orders.map((o) => ...)` block (around line 187), update the props:
+
+```tsx
+              {orders.map((o) => (
+                <OrderRow
+                  key={o.id}
+                  row={o}
+                  isExpanded={expandedId === o.id}
+                  detail={details[o.id]}
+                  printing={printingId === o.id}
+                  editingLoading={editingLoading === o.id}
+                  deleting={deletingId === o.id}
+                  onToggle={() => toggleExpand(o)}
+                  onPrint={() => handlePrint(o)}
+                  onEdit={() => handleEdit(o)}
+                  onDelete={() => setDeletingTarget(o)}
+                />
+              ))}
+```
+
+- [ ] **Step 6: Render the confirm dialog**
+
+Just before the final `</div>` that closes the page (after the `EditOrderDialog` block, around line 210), add:
+
+```tsx
+      {deletingTarget && (
+        <Dialog open onOpenChange={(open) => !open && !deletingId && setDeletingTarget(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Remove this order?</DialogTitle>
+              <DialogDescription>
+                Order {deletingTarget.orderNumber} ({deletingTarget.customerName}) will be hidden
+                from the list and locked so the next Re-sync won't bring it back. You can still
+                see it under <em>Show removed</em>.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setDeletingTarget(null)}
+                disabled={!!deletingId}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={confirmDelete}
+                disabled={!!deletingId}
+              >
+                {deletingId ? 'Removing…' : 'Remove'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+```
+
+- [ ] **Step 7: Type-check and run the existing frontend tests**
+
+From the project root:
+```bash
+npx tsc --noEmit
+npx vitest run --reporter=dot
+```
+Expected: both clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/OrdersPage.tsx
+git commit -m "feat(orders): trash icon + confirm dialog to remove a row"
+```
+
+---
+
+## Phase 2 — Merge orders
+
+### Task 5: Schema migration — `merged_into_id` and `order_item.source_row`
+
+**Files:**
+- Create: `src-tauri/src/db/migrations/0003_merge_orders.sql`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `#[cfg(test)] mod tests` block in `src-tauri/src/db/orders.rs`:
+
+```rust
+#[tokio::test]
+async fn migration_backfills_order_item_source_row() {
+    // After the 0003 migration, every existing order_item should have
+    // source_row populated from its parent order. Confirm by inserting an
+    // order via the normal sync path and reading the column directly.
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let row: (Option<i64>,) = sqlx::query_as(
+        r#"SELECT source_row FROM order_item LIMIT 1"#,
+    ).fetch_one(&pool).await.unwrap();
+    assert_eq!(row.0, Some(11), "source_row should be populated from parent order");
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cargo test --quiet --lib db::orders::tests::migration_backfills_order_item_source_row
+```
+Expected: SQL error — `no such column: source_row`.
+
+- [ ] **Step 3: Create the migration**
+
+Create `src-tauri/src/db/migrations/0003_merge_orders.sql`:
+
+```sql
+-- Merge-orders feature.
+--
+-- merged_into_id: when set, this order has been folded into another order
+-- (the master). The donor row is also soft-deleted (deleted_at set) and is
+-- treated as "not a real order" for everything except sync.
+ALTER TABLE "order" ADD COLUMN merged_into_id TEXT
+    REFERENCES "order"(id);
+CREATE INDEX idx_order_merged_into ON "order"(merged_into_id);
+
+-- order_item.source_row: which sheet row produced this item. For non-merged
+-- orders this matches the parent order's source_row. For merged masters the
+-- master holds items from multiple source_rows; sync uses this tag to refresh
+-- only the items that belong to the row currently being parsed.
+ALTER TABLE order_item ADD COLUMN source_row INTEGER;
+UPDATE order_item
+   SET source_row = (
+     SELECT source_row FROM "order" WHERE "order".id = order_item.order_id
+   );
+```
+
+- [ ] **Step 4: Update Rust structs to read the new column**
+
+In `src-tauri/src/db/orders.rs`, extend the `OrderRow` struct (right after `sync_locked`):
+
+```rust
+    pub sync_locked: i64,
+    pub merged_into_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+```
+
+Extend `OrderItemRow` (file `src-tauri/src/db/orders.rs`, the struct after `OrderRow`):
+
+```rust
+#[derive(Debug, Serialize, Deserialize, Clone, sqlx::FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderItemRow {
+    pub id: String,
+    pub order_id: String,
+    pub product_id: String,
+    pub quantity: i64,
+    pub unit_price: i64,
+    pub source_row: Option<i64>,
+}
+```
+
+- [ ] **Step 5: Run the test**
+
+```bash
+cargo test --quiet --lib db::orders::tests::migration_backfills_order_item_source_row
+```
+Expected: 1 passed.
+
+- [ ] **Step 6: Run the full DB test module to confirm no regressions**
+
+```bash
+cargo test --quiet --lib db::orders
+```
+Expected: all previously-passing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/db/migrations/0003_merge_orders.sql src-tauri/src/db/orders.rs
+git commit -m "feat(orders): migration 0003 — merged_into_id + order_item.source_row"
+```
+
+---
+
+### Task 6: Source-row-scoped item refresh in `upsert_from_source`
+
+Change the item refresh inside `upsert_from_source` so each sheet row only replaces its own items. For non-merged orders this is behaviorally identical (all items share the same `source_row`); the change is what later lets a master order hold items from multiple rows safely.
+
+**Files:**
+- Modify: `src-tauri/src/db/orders.rs:46-160` (`UpsertOrderItemInput` and `upsert_from_source`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test module in `src-tauri/src/db/orders.rs`:
+
+```rust
+#[tokio::test]
+async fn upsert_only_refreshes_items_tagged_with_its_source_row() {
+    // Simulates the post-merge state by hand: one order owns items tagged with
+    // two different source_rows. Re-running upsert for source_row=11 must only
+    // touch items tagged 11 and leave items tagged 12 alone.
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let out = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Hand-insert a second item on the same order tagged with source_row 12.
+    sqlx::query(
+        r#"INSERT INTO order_item (id, order_id, product_id, quantity, unit_price, source_row)
+           VALUES (?, ?, ?, ?, ?, ?)"#,
+    )
+    .bind(new_id()).bind(&out.order_id).bind(&p.id).bind(3_i64).bind(85_i64).bind(12_i64)
+    .execute(&pool).await.unwrap();
+
+    // Re-upsert row 11 with a different quantity — row 12's item must survive.
+    let mut tx = pool.begin().await.unwrap();
+    upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 170, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 11,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 2, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let items: Vec<(i64, Option<i64>)> = sqlx::query_as(
+        r#"SELECT quantity, source_row FROM order_item WHERE order_id = ? ORDER BY source_row"#,
+    ).bind(&out.order_id).fetch_all(&pool).await.unwrap();
+    assert_eq!(items, vec![(2, Some(11)), (3, Some(12))]);
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cargo test --quiet --lib db::orders::tests::upsert_only_refreshes_items_tagged
+```
+Expected: fail — the row 12 item is wiped because the old code does `DELETE FROM order_item WHERE order_id = ?` (wholesale).
+
+- [ ] **Step 3: Update `upsert_from_source`'s item refresh**
+
+In `src-tauri/src/db/orders.rs`, replace the items-refresh block (currently lines 139–157) with:
+
+```rust
+    // Locked rows keep their items as-is. Refresh them only when the row is
+    // either brand new or being updated from the sheet, AND only for items
+    // tagged with this sheet row. Other source_rows' items stay (the merge
+    // feature relies on this: a master order holds items from multiple
+    // source_rows).
+    let is_locked: (i64,) = sqlx::query_as(
+        r#"SELECT sync_locked FROM "order" WHERE id = ?"#,
+    )
+    .bind(&order_id).fetch_one(&mut **tx).await?;
+    if is_locked.0 == 0 {
+        sqlx::query(
+            r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+        )
+        .bind(&order_id).bind(input.source_row).execute(&mut **tx).await?;
+        for item in input.items {
+            sqlx::query(
+                r#"INSERT INTO order_item
+                   (id, order_id, product_id, quantity, unit_price, source_row)
+                   VALUES (?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(new_id()).bind(&order_id).bind(item.product_id)
+            .bind(item.quantity).bind(item.unit_price).bind(input.source_row)
+            .execute(&mut **tx).await?;
+        }
+    }
+```
+
+- [ ] **Step 4: Run the new test**
+
+```bash
+cargo test --quiet --lib db::orders::tests::upsert_only_refreshes_items_tagged
+```
+Expected: 1 passed.
+
+- [ ] **Step 5: Re-run the whole DB module to confirm no regression**
+
+```bash
+cargo test --quiet --lib db::orders
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/db/orders.rs
+git commit -m "refactor(orders): scope upsert's item refresh by source_row"
+```
+
+---
+
+### Task 7: Add `merge_orders` DB function with tests
+
+**Files:**
+- Modify: `src-tauri/src/db/orders.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the test module:
+
+```rust
+#[tokio::test]
+async fn merge_two_orders_moves_items_sums_fees_marks_donor() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 170, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 5,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 2, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Give B a delivery fee so we can confirm the sum.
+    sqlx::query(
+        r#"UPDATE "order" SET delivery_fee = 40, total_amount = total_amount + 40 WHERE id = ?"#,
+    ).bind(&b.order_id).execute(&pool).await.unwrap();
+
+    let out = merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+    // Master = lowest source_row (row 4)
+    assert_eq!(out.master_order_id, a.order_id);
+    assert_eq!(out.merged_count, 1);
+
+    let (master, items) = get_with_items(&pool, &a.order_id).await.unwrap().unwrap();
+    assert_eq!(master.delivery_fee, 40);
+    assert_eq!(master.discount, 0);
+    // 1×85 (row 4) + 2×85 (row 5) + 40 fee = 295
+    assert_eq!(master.total_amount, 295);
+    assert!(master.merged_into_id.is_none());
+    assert_eq!(master.sync_locked, 0, "merge must NOT lock the master");
+    assert_eq!(items.len(), 2);
+
+    let donor = sqlx::query_as::<_, OrderRow>(r#"SELECT * FROM "order" WHERE id = ?"#)
+        .bind(&b.order_id).fetch_one(&pool).await.unwrap();
+    assert_eq!(donor.merged_into_id.as_deref(), Some(a.order_id.as_str()));
+    assert!(donor.deleted_at.is_some());
+    assert_eq!(donor.sync_locked, 0);
+}
+
+#[tokio::test]
+async fn merge_rejects_cross_tab() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-18",
+        source_tab: "Order_31", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    let res = merge_orders(&pool, &[a.order_id, b.order_id]).await;
+    assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn merge_rejects_locked_donor() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 5,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    apply_order_edit(&pool, &b.order_id, &[
+        EditOrderItem { product_id: p.id.clone(), quantity: 1, unit_price: 85 },
+    ], 0, 0).await.unwrap();
+    let res = merge_orders(&pool, &[a.order_id, b.order_id]).await;
+    assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn merge_rejects_already_merged() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 5,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let cc = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 6,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    merge_orders(&pool, &[a.order_id.clone(), b.order_id]).await.unwrap();
+    // b is now merged away; trying to merge it again must fail.
+    let res = merge_orders(&pool, &[a.order_id, cc.order_id]).await;
+    // a is master (not merged-away), cc is fine — this one should actually succeed.
+    assert!(res.is_ok(), "merging into an existing master must work");
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cargo test --quiet --lib db::orders::tests::merge_
+```
+Expected: compile error — `merge_orders` and `MergeOutcome` not defined.
+
+- [ ] **Step 3: Implement `merge_orders`**
+
+In `src-tauri/src/db/orders.rs`, add the type and function (just before the `#[cfg(test)]` block):
+
+```rust
+pub struct MergeOutcome {
+    pub master_order_id: String,
+    pub master_order_number: String,
+    pub merged_count: usize,
+}
+
+/// Merge `order_ids` into one master order. The master is the input order
+/// with the smallest `source_row`. Donor orders are soft-deleted and their
+/// `merged_into_id` points at the master; their items move onto the master,
+/// tagged with the donor's `source_row`. Discount and delivery_fee are summed.
+///
+/// Constraints:
+///   * 2+ ids required.
+///   * All orders must share the same `source_tab`.
+///   * No order may already be merged-away (`merged_into_id IS NOT NULL`).
+///   * No order may be `sync_locked` (manual override; merge would replace it).
+///   * No order may be soft-deleted.
+pub async fn merge_orders(
+    pool: &SqlitePool,
+    order_ids: &[String],
+) -> Result<MergeOutcome, sqlx::Error> {
+    if order_ids.len() < 2 {
+        return Err(sqlx::Error::Protocol(
+            "merge requires at least two orders".into(),
+        ));
+    }
+    let mut rows: Vec<OrderRow> = Vec::with_capacity(order_ids.len());
+    for id in order_ids {
+        let row = sqlx::query_as::<_, OrderRow>(
+            r#"SELECT * FROM "order" WHERE id = ?"#,
+        ).bind(id).fetch_optional(pool).await?
+        .ok_or(sqlx::Error::RowNotFound)?;
+        rows.push(row);
+    }
+    // Constraint checks.
+    let tab = rows[0].source_tab.clone();
+    if tab.is_none() {
+        return Err(sqlx::Error::Protocol("orders missing source_tab cannot be merged".into()));
+    }
+    for r in &rows {
+        if r.source_tab != tab {
+            return Err(sqlx::Error::Protocol(
+                "all orders must share the same source_tab".into()
+            ));
+        }
+        if r.merged_into_id.is_some() {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} is already merged into another", r.order_number).into()
+            ));
+        }
+        if r.sync_locked != 0 {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} has manual edits; unlock before merging", r.order_number).into()
+            ));
+        }
+        if r.deleted_at.is_some() {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} is removed", r.order_number).into()
+            ));
+        }
+    }
+
+    // Master = lowest source_row.
+    rows.sort_by_key(|r| r.source_row.unwrap_or(i64::MAX));
+    let master = rows.remove(0);
+    let donors = rows;
+    let now = now_iso();
+
+    let mut tx = pool.begin().await?;
+
+    // Move each donor's items onto the master, tagged with the donor's source_row.
+    let mut summed_discount = master.discount;
+    let mut summed_delivery = master.delivery_fee;
+    for d in &donors {
+        let donor_row = d.source_row.unwrap_or(0);
+        sqlx::query(
+            r#"UPDATE order_item
+               SET order_id = ?, source_row = ?
+               WHERE order_id = ?"#,
+        )
+        .bind(&master.id).bind(donor_row).bind(&d.id)
+        .execute(&mut *tx).await?;
+
+        summed_discount += d.discount;
+        summed_delivery += d.delivery_fee;
+
+        sqlx::query(
+            r#"UPDATE "order" SET
+                 merged_into_id = ?, deleted_at = ?, sync_locked = 0, updated_at = ?
+               WHERE id = ?"#,
+        )
+        .bind(&master.id).bind(&now).bind(&now).bind(&d.id)
+        .execute(&mut *tx).await?;
+    }
+
+    // Recompute master total = subtotal - discount + delivery_fee.
+    let subtotal: (i64,) = sqlx::query_as(
+        r#"SELECT COALESCE(SUM(quantity * unit_price), 0) FROM order_item WHERE order_id = ?"#,
+    ).bind(&master.id).fetch_one(&mut *tx).await?;
+    let new_total = (subtotal.0 - summed_discount + summed_delivery).max(0);
+
+    sqlx::query(
+        r#"UPDATE "order" SET
+             total_amount = ?, discount = ?, delivery_fee = ?, updated_at = ?
+           WHERE id = ?"#,
+    )
+    .bind(new_total).bind(summed_discount).bind(summed_delivery).bind(&now).bind(&master.id)
+    .execute(&mut *tx).await?;
+
+    tx.commit().await?;
+
+    Ok(MergeOutcome {
+        master_order_id: master.id,
+        master_order_number: master.order_number,
+        merged_count: donors.len(),
+    })
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+cargo test --quiet --lib db::orders::tests::merge_
+```
+Expected: all 4 pass.
+
+- [ ] **Step 5: Re-run the whole module to confirm no regression**
+
+```bash
+cargo test --quiet --lib db::orders
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/db/orders.rs
+git commit -m "feat(orders): merge_orders moves donor items onto master"
+```
+
+---
+
+### Task 8: Hide merged-away rows from `list_by_tab` and `soft_delete_missing_rows`
+
+**Files:**
+- Modify: `src-tauri/src/db/orders.rs:162-205`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test module:
+
+```rust
+#[tokio::test]
+async fn list_hides_merged_away_rows_by_default() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 5,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+    let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+    assert_eq!(alive.len(), 1);
+    assert_eq!(alive[0].id, a.order_id);
+
+    let all = list_by_tab(&pool, Some("Order_30"), true, 100).await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+
+#[tokio::test]
+async fn soft_delete_missing_rows_skips_merged_away() {
+    let pool = init_memory_pool().await.unwrap();
+    let (p, c) = seed_pc(&pool).await;
+    let mut tx = pool.begin().await.unwrap();
+    let a = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 4,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    let b = upsert_from_source(&mut tx, UpsertOrderInput {
+        customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+        total_amount: 85, order_date: "2026-05-11",
+        source_tab: "Order_30", source_row: 5,
+        items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+    }).await.unwrap();
+    tx.commit().await.unwrap();
+    merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+    // Sheet sync says "only row 4 still exists". soft_delete_missing_rows must
+    // ignore row 5's order shell because it's already merged-away — touching
+    // it would re-stamp deleted_at unnecessarily.
+    let mut tx = pool.begin().await.unwrap();
+    let n = soft_delete_missing_rows(&mut tx, "Order_30", &[4]).await.unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(n, 0);
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cargo test --quiet --lib db::orders::tests::list_hides_merged_away_rows_by_default db::orders::tests::soft_delete_missing_rows_skips_merged_away
+```
+Expected: 2 failed (master row 4 still owns row 5's items so the second test passes accidentally; the first test sees both rows because `list_by_tab` doesn't filter yet).
+
+- [ ] **Step 3: Update `list_by_tab`**
+
+In `src-tauri/src/db/orders.rs`, edit `list_by_tab`. After `if !include_deleted { sql.push_str(" AND deleted_at IS NULL"); }`, add:
+
+```rust
+    // Merged-away rows are soft-deleted donors; show them only with include_deleted.
+    if !include_deleted { sql.push_str(" AND merged_into_id IS NULL"); }
+```
+
+- [ ] **Step 4: Update `soft_delete_missing_rows`**
+
+In `src-tauri/src/db/orders.rs`, extend both WHERE clauses in `soft_delete_missing_rows` to also skip merged-away rows:
+
+```rust
+    let sql = if keep_rows.is_empty() {
+        r#"UPDATE "order" SET deleted_at = ?, updated_at = ?
+           WHERE source_tab = ? AND deleted_at IS NULL AND sync_locked = 0
+             AND merged_into_id IS NULL"#.to_string()
+    } else {
+        let placeholders = keep_rows.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        format!(
+            r#"UPDATE "order" SET deleted_at = ?, updated_at = ?
+               WHERE source_tab = ? AND deleted_at IS NULL AND sync_locked = 0
+                 AND merged_into_id IS NULL
+                 AND source_row NOT IN ({})"#,
+            placeholders
+        )
+    };
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+cargo test --quiet --lib db::orders::tests::list_hides_merged_away_rows_by_default db::orders::tests::soft_delete_missing_rows_skips_merged_away
+```
+Expected: 2 passed.
+
+- [ ] **Step 6: Re-run the whole module**
+
+```bash
+cargo test --quiet --lib db::orders
+```
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/db/orders.rs
+git commit -m "feat(orders): hide merged-away rows from list and soft-delete sweep"
+```
+
+---
+
+### Task 9: Sync engine — merged-row pull-through and donor-row cleanup
+
+**Files:**
+- Modify: `src-tauri/src/sync/engine.rs:99-245`
+
+- [ ] **Step 1: Write the failing tests**
+
+Look at the existing test scaffolding in `src-tauri/src/sync/engine.rs` (starting around line 247) for the `FakeSheetsClient` + `make_vr` helpers, then append:
+
+```rust
+#[tokio::test]
+async fn merged_donor_row_edits_flow_into_master() {
+    use crate::db::orders::{merge_orders, get_with_items};
+
+    // Initial sync: two K.Ing rows.
+    let pool = init_memory_pool().await.unwrap();
+    let tab = "Order_30";
+    let make_sheet = |row5_qty: &str| {
+        make_vr(vec![
+            vec!["Menu", "Price", "", "Channel", "Customer", "Choc", "Matcha"],
+            vec!["Choc",  "100",   "", "",        "",         "",     ""],
+            vec!["Matcha","120",   "", "",        "",         "",     ""],
+            vec![ "",      "",      "", "Page",    "K.Ing",    "1",    ""],
+            vec![ "",      "",      "", "Page",    "K.Ing",    "",     row5_qty],
+        ])
+    };
+    let fake = FakeSheetsClient {
+        values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("1"))]),
+    };
+    let preview = preview_sync(&pool, &fake, "x", tab).await.unwrap();
+    let mappings = SyncMappings {
+        menu: preview.unknown_menus.iter().map(|m| (m.alias.clone(),
+            MenuMappingChoice::Create { name_th: m.alias.clone(), name_en: None, selling_price: m.suggested_price })).collect(),
+        customer: preview.unknown_customers.iter().map(|c| (c.alias.clone(),
+            CustomerMappingChoice::Create { name: c.alias.clone() })).collect(),
+    };
+    apply_sync(&pool, &fake, "x", tab, mappings).await.unwrap();
+
+    // Merge the two K.Ing rows.
+    let orders = crate::db::orders::list_by_tab(&pool, Some(tab), false, 100).await.unwrap();
+    assert_eq!(orders.len(), 2);
+    let ids: Vec<String> = orders.iter().map(|o| o.id.clone()).collect();
+    let merged = merge_orders(&pool, &ids).await.unwrap();
+
+    // Wife edits row 5 in the sheet to qty=3.
+    let fake2 = FakeSheetsClient {
+        values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("3"))]),
+    };
+    let preview2 = preview_sync(&pool, &fake2, "x", tab).await.unwrap();
+    let mappings2 = SyncMappings { menu: vec![], customer: vec![] };
+    apply_sync(&pool, &fake2, "x", tab, mappings2).await.unwrap();
+    let _ = preview2;
+
+    // Master now reflects qty=3 for the row-5 item; qty=1 for row-4 still.
+    let (master, items) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+    let row4 = items.iter().find(|i| i.source_row == Some(4)).expect("row 4 item");
+    let row5 = items.iter().find(|i| i.source_row == Some(5)).expect("row 5 item");
+    assert_eq!(row4.quantity, 1);
+    assert_eq!(row5.quantity, 3);
+    // Total = 100 + 120*3 = 460
+    assert_eq!(master.total_amount, 460);
+}
+
+#[tokio::test]
+async fn merged_donor_row_removed_from_sheet_strips_its_items_from_master() {
+    use crate::db::orders::{merge_orders, get_with_items};
+
+    let pool = init_memory_pool().await.unwrap();
+    let tab = "Order_30";
+    let two_rows = make_vr(vec![
+        vec!["Menu","Price","","Channel","Customer","Choc","Matcha"],
+        vec!["Choc","100","","","","",""],
+        vec!["Matcha","120","","","","",""],
+        vec!["","","","Page","K.Ing","1",""],
+        vec!["","","","Page","K.Ing","","1"],
+    ]);
+    let fake = FakeSheetsClient {
+        values: HashMap::from([(format!("{}!A1:Z200", tab), two_rows)]),
+    };
+    let p = preview_sync(&pool, &fake, "x", tab).await.unwrap();
+    apply_sync(&pool, &fake, "x", tab, SyncMappings {
+        menu: p.unknown_menus.iter().map(|m| (m.alias.clone(),
+            MenuMappingChoice::Create { name_th: m.alias.clone(), name_en: None, selling_price: m.suggested_price })).collect(),
+        customer: p.unknown_customers.iter().map(|c| (c.alias.clone(),
+            CustomerMappingChoice::Create { name: c.alias.clone() })).collect(),
+    }).await.unwrap();
+
+    let orders = crate::db::orders::list_by_tab(&pool, Some(tab), false, 100).await.unwrap();
+    let ids: Vec<String> = orders.iter().map(|o| o.id.clone()).collect();
+    let merged = merge_orders(&pool, &ids).await.unwrap();
+
+    // Sheet drops row 5.
+    let one_row = make_vr(vec![
+        vec!["Menu","Price","","Channel","Customer","Choc","Matcha"],
+        vec!["Choc","100","","","","",""],
+        vec!["Matcha","120","","","","",""],
+        vec!["","","","Page","K.Ing","1",""],
+    ]);
+    let fake2 = FakeSheetsClient {
+        values: HashMap::from([(format!("{}!A1:Z200", tab), one_row)]),
+    };
+    let _ = preview_sync(&pool, &fake2, "x", tab).await.unwrap();
+    apply_sync(&pool, &fake2, "x", tab, SyncMappings { menu: vec![], customer: vec![] }).await.unwrap();
+
+    let (master, items) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+    assert_eq!(items.len(), 1, "row 5's item must be gone");
+    assert_eq!(items[0].source_row, Some(4));
+    assert_eq!(master.total_amount, 100);
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cargo test --quiet --lib sync::engine::tests::merged_donor_row_edits_flow_into_master sync::engine::tests::merged_donor_row_removed_from_sheet_strips
+```
+Expected: failures — the engine doesn't yet route donor-row updates into the master.
+
+- [ ] **Step 3a: Update `preview_sync`'s counters**
+
+In `src-tauri/src/sync/engine.rs`, find the block that builds `existing_rows` (around lines 76–86). The current query filters by `deleted_at IS NULL`, which excludes merged-away rows and makes them look like inserts. Replace the block with:
+
+```rust
+    // Existing rows includes merged-away donors. We treat them as "exists"
+    // so the preview counters categorize sheet edits to them as updates,
+    // not inserts.
+    let existing: Vec<(i64,)> = sqlx::query_as(
+        r#"SELECT source_row FROM "order"
+           WHERE source_tab = ?
+             AND (deleted_at IS NULL OR merged_into_id IS NOT NULL)"#,
+    )
+    .bind(tab).fetch_all(pool).await?;
+    let existing_rows: std::collections::HashSet<i64> = existing.into_iter().map(|t| t.0).collect();
+    let parsed_rows: std::collections::HashSet<i64> = parsed.orders.iter().map(|o| o.source_row).collect();
+
+    let will_insert = parsed_rows.difference(&existing_rows).count() as i64;
+    let will_update = parsed_rows.intersection(&existing_rows).count() as i64;
+    let will_soft_delete = existing_rows.difference(&parsed_rows).count() as i64;
+```
+
+- [ ] **Step 3b: Update `apply_sync` for the pull-through**
+
+In `src-tauri/src/sync/engine.rs`, find the order upsert loop (currently lines 195–232) and replace it with this version. The diff: before calling `upsert_from_source`, look up whether the row is a known donor and redirect items onto the master.
+
+```rust
+    let mut tx = pool.begin().await?;
+    let mut added = 0i64;
+    let mut updated = 0i64;
+    let mut keep_rows: Vec<i64> = Vec::new();
+    let mut masters_to_recompute: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for ord in &preview.parsed_orders {
+        let cust_id = customer_alias_to_id.get(&ord.customer)
+            .ok_or_else(|| anyhow!("Unresolved customer {}", ord.customer))?.clone();
+
+        let mut total: i64 = 0;
+        let mut item_data: Vec<(String, i64, i64)> = Vec::new();
+        for item in &ord.items {
+            let pid = menu_alias_to_product.get(&item.menu_name)
+                .ok_or_else(|| anyhow!("Unresolved menu {}", item.menu_name))?
+                .clone();
+            let unit = *product_price_by_id.get(&pid).unwrap_or(&0);
+            total += unit * item.quantity;
+            item_data.push((pid, item.quantity, unit));
+        }
+
+        // Pull-through path: if this row was merged into another order, refresh
+        // the master's items tagged with this row's source_row instead of doing
+        // the normal upsert (which would resurrect the donor's order shell).
+        let donor_master: Option<String> = sqlx::query_as::<_, (Option<String>,)>(
+            r#"SELECT merged_into_id FROM "order" WHERE source_tab = ? AND source_row = ?"#,
+        )
+        .bind(tab).bind(ord.source_row)
+        .fetch_optional(&mut *tx).await?
+        .and_then(|(m,)| m);
+
+        if let Some(master_id) = donor_master {
+            sqlx::query(
+                r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+            )
+            .bind(&master_id).bind(ord.source_row).execute(&mut *tx).await?;
+            for (pid, qty, unit) in &item_data {
+                sqlx::query(
+                    r#"INSERT INTO order_item
+                       (id, order_id, product_id, quantity, unit_price, source_row)
+                       VALUES (?, ?, ?, ?, ?, ?)"#,
+                )
+                .bind(crate::db::ids::new_id())
+                .bind(&master_id).bind(pid).bind(qty).bind(unit).bind(ord.source_row)
+                .execute(&mut *tx).await?;
+            }
+            masters_to_recompute.insert(master_id);
+            keep_rows.push(ord.source_row);
+            updated += 1;
+            continue;
+        }
+
+        let items: Vec<orders::UpsertOrderItemInput<'_>> = item_data.iter().map(|(pid, qty, unit)| {
+            orders::UpsertOrderItemInput {
+                product_id: pid.as_str(),
+                quantity: *qty,
+                unit_price: *unit,
+            }
+        }).collect();
+        let out = orders::upsert_from_source(&mut tx, orders::UpsertOrderInput {
+            customer_id: &cust_id,
+            channel: ord.channel.as_deref(),
+            delivery_location: ord.delivery_location.as_deref(),
+            notes: ord.notes.as_deref(),
+            total_amount: total,
+            order_date: &preview.week_start_date,
+            source_tab: tab,
+            source_row: ord.source_row,
+            items,
+        }).await?;
+        if out.was_insert { added += 1; } else { updated += 1; }
+        keep_rows.push(ord.source_row);
+    }
+
+    let soft_deleted = orders::soft_delete_missing_rows(&mut tx, tab, &keep_rows).await?;
+
+    // If a donor row vanished from the sheet, its items must vanish from the
+    // master too. soft_delete_missing_rows skips merged-away rows, so we
+    // detect them here and strip their items.
+    let stale_donors: Vec<(String, i64)> = sqlx::query_as(
+        r#"SELECT merged_into_id, source_row FROM "order"
+           WHERE source_tab = ?
+             AND merged_into_id IS NOT NULL
+             AND source_row IS NOT NULL"#,
+    ).bind(tab).fetch_all(&mut *tx).await?;
+    for (master_id, row) in stale_donors {
+        if !keep_rows.contains(&row) {
+            sqlx::query(
+                r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+            )
+            .bind(&master_id).bind(row).execute(&mut *tx).await?;
+            masters_to_recompute.insert(master_id);
+        }
+    }
+
+    // Recompute totals for any master that changed.
+    for master_id in &masters_to_recompute {
+        let row: (i64, i64, i64) = sqlx::query_as(
+            r#"SELECT
+                 COALESCE(SUM(oi.quantity * oi.unit_price), 0) AS subtotal,
+                 o.discount, o.delivery_fee
+               FROM "order" o
+               LEFT JOIN order_item oi ON oi.order_id = o.id
+               WHERE o.id = ?
+               GROUP BY o.id"#,
+        ).bind(master_id).fetch_one(&mut *tx).await?;
+        let new_total = (row.0 - row.1 + row.2).max(0);
+        sqlx::query(
+            r#"UPDATE "order" SET total_amount = ?, updated_at = ? WHERE id = ?"#,
+        ).bind(new_total).bind(crate::db::ids::now_iso()).bind(master_id)
+        .execute(&mut *tx).await?;
+    }
+
+    tx.commit().await?;
+```
+
+(The rest of the function — `upsert_week_mapping`, `insert_sync_log`, return — stays unchanged.)
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+cargo test --quiet --lib sync::engine::tests::merged_donor_row_edits_flow_into_master sync::engine::tests::merged_donor_row_removed_from_sheet_strips
+```
+Expected: 2 passed.
+
+- [ ] **Step 5: Re-run all backend tests**
+
+```bash
+cargo test --quiet --lib
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/sync/engine.rs
+git commit -m "feat(sync): route donor-row edits into the master order"
+```
+
+---
+
+### Task 10: Expose `merge_orders` as a Tauri command + serialize `merged_into_id` to the frontend
+
+**Files:**
+- Modify: `src-tauri/src/commands/orders.rs` (add `MergeResult`, `merge_orders` command; add `merged_into_id` to `OrderListRow` / `OrderDetail`)
+- Modify: `src-tauri/src/lib.rs:30-45`
+
+- [ ] **Step 1: Add `merged_into_id` to the serialized structs**
+
+In `src-tauri/src/commands/orders.rs`, edit `OrderListRow`:
+
+```rust
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderListRow {
+    pub id: String,
+    pub order_number: String,
+    pub customer_name: String,
+    pub channel: Option<String>,
+    pub delivery_location: Option<String>,
+    pub total_amount: i64,
+    pub source_tab: Option<String>,
+    pub source_row: Option<i64>,
+    pub printed_at: Option<String>,
+    pub print_count: i64,
+    pub deleted_at: Option<String>,
+    pub order_date: String,
+    pub notes: Option<String>,
+    pub items_summary: String,
+    pub sync_locked: bool,
+    pub merged_into_id: Option<String>,
+    pub merged_from_count: i64,
+}
+```
+
+Edit `OrderDetail` similarly, adding the same two fields at the end of the struct.
+
+In `list_orders` (around line 78), after computing `items_summary`, also count merged donors and populate the new fields. Replace the `out.push(OrderListRow { ... })` block with:
+
+```rust
+        let merged_from_count: (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
+        ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
+        out.push(OrderListRow {
+            id: r.id, order_number: r.order_number, customer_name: cust,
+            channel: r.channel, delivery_location: r.delivery_location,
+            total_amount: r.total_amount,
+            source_tab: r.source_tab, source_row: r.source_row,
+            printed_at: r.printed_at, print_count: r.print_count,
+            deleted_at: r.deleted_at, order_date: r.order_date,
+            notes: r.notes, items_summary,
+            sync_locked: r.sync_locked != 0,
+            merged_into_id: r.merged_into_id,
+            merged_from_count: merged_from_count.0,
+        });
+```
+
+In `get_order` (around line 116), inside the final `Ok(Some(OrderDetail { ... }))` block, add `merged_into_id: r.merged_into_id.clone(),` and `merged_from_count: { let c: (i64,) = sqlx::query_as(r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?; c.0 },` just before `items: detail_items,`.
+
+- [ ] **Step 2: Add `merge_orders` command**
+
+Append to `src-tauri/src/commands/orders.rs`:
+
+```rust
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeResult {
+    pub master_order_id: String,
+    pub master_order_number: String,
+    pub merged_count: usize,
+}
+
+#[tauri::command]
+pub async fn merge_orders(
+    state: State<'_, AppState>,
+    order_ids: Vec<String>,
+) -> Result<MergeResult, String> {
+    let out = orders::merge_orders(&state.db, &order_ids).await.map_err(|e| e.to_string())?;
+    Ok(MergeResult {
+        master_order_id: out.master_order_id,
+        master_order_number: out.master_order_number,
+        merged_count: out.merged_count,
+    })
+}
+```
+
+- [ ] **Step 3: Register the command**
+
+In `src-tauri/src/lib.rs`, add `commands::orders::merge_orders,` to the `invoke_handler` block alongside `delete_order`.
+
+- [ ] **Step 4: Verify the backend builds**
+
+```bash
+cargo build --quiet
+```
+Expected: compiles without warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/orders.rs src-tauri/src/lib.rs
+git commit -m "feat(orders): merge_orders command + expose merged metadata to UI"
+```
+
+---
+
+### Task 11: TypeScript types and `ordersApi.merge`
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/tauri.ts`
+
+- [ ] **Step 1: Extend types**
+
+In `src/lib/types.ts`, add to `OrderListRow`:
+
+```ts
+export interface OrderListRow {
+  id: string;
+  orderNumber: string;
+  customerName: string;
+  channel: string | null;
+  deliveryLocation: string | null;
+  totalAmount: number;
+  sourceTab: string | null;
+  sourceRow: number | null;
+  printedAt: string | null;
+  printCount: number;
+  deletedAt: string | null;
+  orderDate: string;
+  notes: string | null;
+  itemsSummary: string;
+  syncLocked: boolean;
+  mergedIntoId: string | null;
+  mergedFromCount: number;
+}
+```
+
+Add the same two fields to `OrderDetail`. Add a new interface:
+
+```ts
+export interface MergeResult {
+  masterOrderId: string;
+  masterOrderNumber: string;
+  mergedCount: number;
+}
+```
+
+- [ ] **Step 2: Extend the API binding**
+
+In `src/lib/tauri.ts`, import `MergeResult` from `./types` and extend `ordersApi`:
+
+```ts
+  delete: (id: string) => invoke<void>('delete_order', { id }),
+  merge: (orderIds: string[]) =>
+    invoke<MergeResult>('merge_orders', { orderIds }),
+};
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/tauri.ts
+git commit -m "feat(orders): types + ordersApi.merge"
+```
+
+---
+
+### Task 12: UI — multi-select toolbar, merge confirm dialog, merged badge
+
+**Files:**
+- Modify: `src/pages/OrdersPage.tsx`
+
+- [ ] **Step 1: Add multi-select state and merge handler**
+
+In `OrdersPage`, after the `deletingTarget` state added in Task 4, add:
+
+```tsx
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [merging, setMerging] = useState(false);
+  const [mergeConfirm, setMergeConfirm] = useState<OrderListRow[] | null>(null);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const openMergeConfirm = () => {
+    const selected = orders.filter((o) => selectedIds.has(o.id));
+    if (selected.length < 2) return;
+    setMergeConfirm(selected);
+  };
+
+  const confirmMerge = async () => {
+    if (!mergeConfirm) return;
+    setMerging(true);
+    try {
+      await ordersApi.merge(mergeConfirm.map((o) => o.id));
+      setMergeConfirm(null);
+      setSelectedIds(new Set());
+      setDetails({});
+      await fetchOrders();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMerging(false);
+    }
+  };
+```
+
+Also, after `fetchOrders` finishes, drop selections that no longer exist. Add inside `fetchOrders`, right after `setOrders(rows);`:
+
+```tsx
+      setSelectedIds((prev) => {
+        const validIds = new Set(rows.map((r) => r.id));
+        const next = new Set<string>();
+        prev.forEach((id) => { if (validIds.has(id)) next.add(id); });
+        return next;
+      });
+```
+
+- [ ] **Step 2: Add the selection checkbox column and merge button**
+
+Update the header to include a leading checkbox column. Inside the `<thead>` block:
+
+```tsx
+            <thead className="sticky top-0 bg-card border-b border-border z-10">
+              <tr className="text-muted-foreground text-xs uppercase tracking-wide text-left">
+                <th className="w-10 px-2 py-3"></th>
+                <th className="w-10 px-2 py-3"></th>
+                <th className="px-3 py-3 font-medium">Order #</th>
+                <th className="px-3 py-3 font-medium">Customer</th>
+                <th className="px-3 py-3 font-medium">Channel</th>
+                <th className="px-3 py-3 font-medium">Items / Delivery</th>
+                <th className="px-3 py-3 font-medium text-right">Total</th>
+                <th className="px-3 py-3 font-medium">Note</th>
+                <th className="w-20 px-2 py-3 font-medium"></th>
+                <th className="w-32 px-3 py-3 font-medium text-right"></th>
+              </tr>
+            </thead>
+```
+
+In `OrderRow`, add a checkbox `<td>` as the first cell:
+
+```tsx
+        <td
+          className="w-10 px-2 py-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {!removed && (
+            <Checkbox
+              checked={selected}
+              onCheckedChange={() => onSelect()}
+              aria-label={`Select order ${row.orderNumber}`}
+            />
+          )}
+        </td>
+```
+
+Add `selected: boolean;` and `onSelect: () => void;` to `OrderRowProps`. Pass them when rendering:
+
+```tsx
+                  selected={selectedIds.has(o.id)}
+                  onSelect={() => toggleSelect(o.id)}
+```
+
+In the header bar of the page (around line 125), add a merge button that appears when ≥2 rows are selected. Just before the `<Button variant="outline" onClick={fetchOrders}>` (Refresh), insert:
+
+```tsx
+        {selectedIds.size >= 2 && (
+          <Button onClick={openMergeConfirm} disabled={merging}>
+            Merge {selectedIds.size} orders
+          </Button>
+        )}
+```
+
+- [ ] **Step 3: Render the merged badge on master rows**
+
+In `OrderRow`, edit the order-number cell to show a `merged ×N` pill when `row.mergedFromCount > 0`:
+
+```tsx
+        <td className="px-3 py-3 font-mono text-sm">
+          <div className="flex items-center gap-2">
+            <span>{row.orderNumber}</span>
+            {row.syncLocked && (
+              <Badge variant="warning" className="gap-1 font-normal" title="Locked from sync">
+                <Lock className="h-3 w-3" />
+                locked
+              </Badge>
+            )}
+            {row.mergedFromCount > 0 && (
+              <Badge variant="muted" className="gap-1 font-normal" title="This order has merged-in rows">
+                merged ×{row.mergedFromCount + 1}
+              </Badge>
+            )}
+            {row.mergedIntoId && (
+              <Badge variant="muted" className="font-normal" title="Merged into another order">
+                merged into
+              </Badge>
+            )}
+          </div>
+        </td>
+```
+
+- [ ] **Step 4: Render the merge confirm dialog**
+
+After the delete confirm dialog block, add:
+
+```tsx
+      {mergeConfirm && (
+        <Dialog open onOpenChange={(open) => !open && !merging && setMergeConfirm(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Merge {mergeConfirm.length} orders?</DialogTitle>
+              <DialogDescription>
+                {(() => {
+                  const sorted = [...mergeConfirm].sort(
+                    (a, b) => (a.sourceRow ?? 0) - (b.sourceRow ?? 0)
+                  );
+                  const master = sorted[0];
+                  const donors = sorted.slice(1);
+                  const customers = new Set(mergeConfirm.map((o) => o.customerName));
+                  const sameCustomer = customers.size === 1;
+                  if (sameCustomer) {
+                    return (
+                      <>
+                        All items will be combined under <strong>{master.orderNumber}</strong>{' '}
+                        ({master.customerName}). They'll receive one receipt with all items and
+                        one QR code.
+                      </>
+                    );
+                  }
+                  return (
+                    <>
+                      {donors.map((d) => d.customerName).join(', ')}'s order
+                      {donors.length > 1 ? 's' : ''} will be merged into{' '}
+                      <strong>{master.customerName}</strong>'s order ({master.orderNumber}).
+                      Only <strong>{master.customerName}</strong> will receive a receipt.
+                    </>
+                  );
+                })()}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setMergeConfirm(null)}
+                disabled={merging}
+              >
+                Cancel
+              </Button>
+              <Button onClick={confirmMerge} disabled={merging}>
+                {merging ? 'Merging…' : 'Merge'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+```
+
+- [ ] **Step 5: Adjust `colSpan` for the expand row**
+
+In the expanded detail `<tr>`, change `colSpan={8}` to `colSpan={9}` to account for the new checkbox column:
+
+```tsx
+      {isExpanded && !removed && (
+        <tr className="bg-accent/20">
+          <td></td>
+          <td colSpan={9} className="px-3 py-4">
+```
+
+- [ ] **Step 6: Type-check and run tests**
+
+```bash
+npx tsc --noEmit
+npx vitest run --reporter=dot
+```
+Expected: both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/OrdersPage.tsx
+git commit -m "feat(orders): multi-select + merge with same/cross-customer confirms"
+```
+
+---
+
+### Task 13: Final preflight
+
+- [ ] **Step 1: Run all backend tests**
+
+```bash
+cd src-tauri && cargo test --quiet --lib
+```
+Expected: every test passes.
+
+- [ ] **Step 2: Run frontend tests + type-check**
+
+```bash
+npx tsc --noEmit && npx vitest run --reporter=dot
+```
+Expected: clean.
+
+- [ ] **Step 3: Build the production bundle**
+
+```bash
+npm run build
+```
+Expected: no errors.
+
+- [ ] **Step 4: Manual smoke test on a local sheet (recommended)**
+
+Run `npm run tauri dev`, then:
+- Open the Orders tab. Confirm trash icon appears next to the edit icon.
+- Delete one row, confirm it disappears, toggle "Show removed" to see it.
+- Re-sync — the deleted row stays gone.
+- Select two K.Ing rows, click Merge, accept the same-customer confirm. Master gains both items, donor disappears.
+- Edit the donor row in the sheet (change qty). Re-sync. Master reflects the change.
+- Delete the donor row from the sheet. Re-sync. Master no longer contains the donor's items.
+
+This step is optional in a CI/agentic context but recommended before merging the PR.
+
+- [ ] **Step 5: Final commit if any docs/changelog updates landed during smoke test**
+
+If nothing else changed, skip this step. Otherwise:
+
+```bash
+git add -A
+git commit -m "docs/chore: tidy up after smoke test"
+```

--- a/docs/superpowers/specs/2026-05-23-merge-orders-design.md
+++ b/docs/superpowers/specs/2026-05-23-merge-orders-design.md
@@ -1,0 +1,307 @@
+# Merge Orders & Delete Row — Design
+
+**Date:** 2026-05-23
+**Status:** Approved for planning
+**Brainstorm:** [`docs/brainstorms/2026-05-23-duplicate-rows.html`](../../brainstorms/2026-05-23-duplicate-rows.html)
+
+## Problem
+
+The cashier (wife) sometimes writes one customer across multiple rows in the
+Google Sheet so the kitchen prepares each cake separately. At checkout the
+customer pays once and wants **one receipt** with both items. Today every sheet
+row becomes its own order with its own receipt and QR code, so the cashier has
+no way to combine them. There is also no way to remove an accidental duplicate
+row from the app.
+
+The Google Sheet is the source of truth for orders. Anything we do in-app must
+survive `Re-sync` without silently undoing itself.
+
+## Scope
+
+This spec covers two related features:
+
+1. **Delete row** (Phase 1) — soft-delete a single order from the Orders list.
+2. **Merge orders** (Phase 2) — combine 2+ orders into one master order whose
+   line items keep flowing from their original sheet rows.
+
+Out of scope:
+
+- **Un-merge button.** Deferred. The merge confirm dialog is expected to catch
+  accidents. We can add un-merge later if the need is real.
+- **Group / link without merging** (Option C from the brainstorm). Deferred.
+- **"Print together" without DB merge** (Option A). Deferred.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Block merge across different customer names? | No — lenient, with a confirm dialog. |
+| Discount + delivery fee on merge | Sum both. If the cashier wants them split, she doesn't merge. |
+| Master row deleted from sheet later | Remove its row-tagged items from master; soft-delete the master if nothing's left. Surface a sync notice. |
+| Un-merge button | Defer to a later phase. |
+| Sheet edits to a merged-away row | Flow through transparently into the master (see "Sync behavior" below). |
+
+## Phase 1 — Delete a row
+
+### UX
+
+- Each row in the Orders list gets a trash icon next to the existing pencil
+  (edit) icon. Disabled when the row is already soft-deleted.
+- Clicking opens a confirm dialog: *"Remove this order from the list? It will
+  be hidden but kept in the database. Re-sync will not bring it back."*
+- After confirm: the row disappears unless `Show removed` is on.
+
+### Data
+
+No new columns. Re-uses existing `deleted_at` and `sync_locked` on `"order"`.
+
+A user-initiated delete sets:
+
+- `deleted_at = now()`
+- `sync_locked = 1` (so the next sync doesn't resurrect it)
+- `updated_at = now()`
+
+### Commands
+
+New Tauri command:
+
+```rust
+#[tauri::command]
+pub async fn delete_order(order_id: String) -> Result<()>
+```
+
+Behavior:
+
+- Returns an error if the order is already soft-deleted.
+- Returns an error if the order has been merged into another order (Phase 2).
+
+### Tests
+
+- Soft-deleting a row hides it from `list_by_tab` with `include_deleted = false`.
+- Re-sync does not resurrect the soft-deleted, locked row.
+- A row that has been soft-deleted appears under `Show removed` with the
+  "removed" badge that already exists.
+
+## Phase 2 — Merge orders
+
+### UX
+
+- Orders list gets a leading checkbox column. Selecting ≥1 row reveals a
+  toolbar with **Merge** and **Delete** actions.
+- Merge is enabled when ≥2 rows are selected and none of them are already
+  soft-deleted or merged-away.
+- Master = the selected row with the lowest `source_row` (the earliest one).
+- Confirm dialog before commit:
+  - If all selected rows share the same customer:
+    *"Merge 2 orders into Order_30-04 (K.Ing)? She'll receive one receipt with
+    all items combined."*
+  - If customers differ:
+    *"Merge P.Som's order into K.Ing's order? P.Som's items will appear on
+    K.Ing's combined receipt. P.Som will not receive a separate receipt."*
+- After merge:
+  - Master row shows a `merged ×N` pill next to its order number.
+  - Merged-away rows are hidden by default; visible under `Show removed` with a
+    `merged into <master_order_number>` badge.
+  - Master's detail panel lists items grouped by their originating
+    `source_row` (e.g. *"From row 04: Choc Lava ฿180 — From row 05: Matcha Roll
+    ฿220"*).
+
+### Data
+
+**New column on `"order"`:**
+
+```sql
+ALTER TABLE "order" ADD COLUMN merged_into_id TEXT
+    REFERENCES "order"(id);
+CREATE INDEX idx_order_merged_into ON "order"(merged_into_id);
+```
+
+`merged_into_id IS NULL` for normal and master orders. Set on merged-away rows
+to point at the master.
+
+**New column on `order_item`:**
+
+```sql
+ALTER TABLE order_item ADD COLUMN source_row INTEGER;
+```
+
+Every item carries the `source_row` it was parsed from. For pre-migration
+items, backfill from `"order".source_row` so existing data is consistent.
+
+`source_tab` is not needed on `order_item` — all items in a single master order
+necessarily belong to the same tab as the master, and merge across tabs is not
+supported (see Constraints).
+
+### Constraints
+
+- Merge is only allowed for orders in the **same `source_tab`** (same week).
+  Cross-week merge is rejected with a toast: *"Can't merge orders from
+  different weeks."*
+- Cannot merge an already-merged-away order. Cannot merge into a soft-deleted
+  master.
+- Locked orders (`sync_locked = 1`) cannot participate in a merge — the locked
+  flag means the user has manually overridden values and merge would replace
+  them. Reject with: *"Order_30-04 has manual edits; unlock it (or use only
+  unlocked orders) before merging."*
+
+### Commands
+
+```rust
+#[tauri::command]
+pub async fn merge_orders(order_ids: Vec<String>) -> Result<MergeOutcome>
+
+pub struct MergeOutcome {
+    pub master_order_id: String,
+    pub master_order_number: String,
+    pub merged_count: usize,
+}
+```
+
+Algorithm (inside one transaction):
+
+1. Load all input orders. Validate constraints above.
+2. Choose master = the order with the smallest `source_row`.
+3. For each non-master order:
+   - Re-parent items, tagging them with the donor's `source_row`:
+     `UPDATE order_item SET order_id = <master>, source_row = <donor.source_row> WHERE order_id = <donor>`
+     (the SET on `source_row` is a no-op if the migration backfill already set it correctly; doing it explicitly here is defensive against any edge where a manual edit dropped the tag).
+   - Add the donor's `discount` and `delivery_fee` to the master.
+   - Set on the donor: `merged_into_id = <master>`, `deleted_at = now()`,
+     `sync_locked = 0`, `updated_at = now()`.
+4. Recompute master's `total_amount`:
+   `sum(items.unit_price * items.quantity) - discount + delivery_fee`.
+5. Bump master's `updated_at`.
+
+The master's `sync_locked` is **not** changed by merge. Merging is not a
+manual edit — it's a regrouping. Sheet edits should keep flowing.
+
+### Sync behavior changes
+
+The sync engine's existing flow is "for each parsed sheet row, upsert by
+`(source_tab, source_row)`". The merge feature changes how items are refreshed:
+each sheet row only owns the items tagged with its own `source_row`, never
+the whole order's items. This unifies the master and non-merged cases.
+
+**Refactor `upsert_from_source`'s item refresh.** Today it does
+`DELETE FROM order_item WHERE order_id = ?` (wipes all items) then inserts.
+After this change, the delete is scoped:
+
+```sql
+DELETE FROM order_item WHERE order_id = ? AND source_row = ?
+```
+
+then inserts the freshly parsed items, each tagged with that `source_row`.
+For non-merged orders this is identical to the old behavior (all items share
+the same source_row as their parent order). For merged masters, items
+contributed by other rows are preserved.
+
+**Three additions to the sync engine:**
+
+1. **Items tag.** Every item written by sync (insert or refresh) carries the
+   `source_row` of the sheet row that produced it. Existing items get this
+   via the migration backfill.
+
+2. **Merged-row pull-through.** Before calling `upsert_from_source`, the
+   engine looks up the order keyed by `(source_tab, source_row)`. If that
+   order has `merged_into_id IS NOT NULL`:
+   - Treat the master as the upsert target instead of the donor's order
+     shell.
+   - Run the same source_row-scoped delete-then-insert against the master,
+     using the donor row's `source_row` as the tag.
+   - Recompute master `total_amount` after the items change.
+   - Do not touch the donor's own order row (it stays soft-deleted with
+     `merged_into_id` intact).
+
+3. **Merged-row deletion from the sheet.** The existing
+   `soft_delete_missing_rows` skips locked rows. Extend it to also ignore
+   rows with `merged_into_id` set (they're already soft-deleted). For each
+   merged-away row whose sheet row has disappeared:
+   - Delete items in the master tagged with that `source_row`.
+   - Recompute master `total_amount`.
+   - If the master now has zero items AND its own sheet row is also gone,
+     soft-delete the master.
+
+The preview command (`preview_sync`) needs the same logic in its counters so
+the "+N / ~N / -N" numbers match what apply will do. A merged-away row whose
+sheet row is unchanged counts as 0 (no-op); a changed merged-away row counts
+as 1 update (against the master).
+
+### List query change
+
+`list_by_tab` adds `AND merged_into_id IS NULL` to the default WHERE so the
+hidden donor rows don't show. Under `include_deleted = true` they show with the
+`merged into <master_number>` badge so the cashier can audit.
+
+### Tests
+
+Database layer (`src-tauri/src/db/orders.rs`):
+
+- Merging 2 orders moves items, sums discount + delivery_fee, sets
+  `merged_into_id`, soft-deletes the donor.
+- Merge rejects different `source_tab`s.
+- Merge rejects locked donors.
+- Merge rejects already-merged orders.
+- Merging 3 orders with the same customer: master is the lowest source_row;
+  items from all 3 land on master tagged with their original source_rows.
+
+Sync engine (`src-tauri/src/sync/engine.rs`):
+
+- After merge, re-sync with the same sheet data is a no-op (items, totals,
+  merged_into_id all stable).
+- After merge, editing the donor row in the sheet (adding an item) flows into
+  the master: master gains the new item tagged with that source_row, total
+  recomputed.
+- After merge, deleting the donor row from the sheet removes its items from
+  master and recomputes the total. Master itself survives if it still has
+  items.
+- After merge, deleting both donor and master rows from the sheet
+  soft-deletes the master.
+- Re-syncing does NOT resurrect a merged-away row's own order shell.
+
+Frontend (`src/pages/OrdersPage.tsx`):
+
+- Selecting ≥2 rows reveals the merge toolbar.
+- Same-customer merge confirm vs. cross-customer merge confirm differ in
+  wording.
+- Merged orders show `merged ×N` pill and grouped item breakdown in detail
+  panel.
+
+## Migration
+
+One new migration file:
+
+```text
+src-tauri/src/db/migrations/0003_merge_orders.sql
+```
+
+Contents:
+
+1. `ALTER TABLE "order" ADD COLUMN merged_into_id TEXT REFERENCES "order"(id);`
+2. `CREATE INDEX idx_order_merged_into ON "order"(merged_into_id);`
+3. `ALTER TABLE order_item ADD COLUMN source_row INTEGER;`
+4. Backfill: `UPDATE order_item SET source_row = (SELECT source_row FROM "order" WHERE "order".id = order_item.order_id);`
+
+No data loss. Existing orders keep working exactly as before; the new columns
+are inert until a merge is performed.
+
+## Open items deliberately not designed
+
+- **Customer-rename propagation:** if a donor row's customer is renamed in the
+  sheet after merge, we keep the master's customer (master is the donor row's
+  master). No warning. Document this in the user-facing help when we add one.
+- **Reports / analytics:** there are none today. When they're added, a
+  merged-away row should not be counted separately; treating
+  `merged_into_id IS NOT NULL` as "not a real order" handles this.
+- **Status bar warnings about merged orders:** none beyond what already
+  exists. If we discover the cashier needs explicit notifications ("this
+  merged order changed during sync"), we can add them later from the same
+  `sync_log` surface that exists today.
+
+## Phasing
+
+| Phase | Effort | Scope |
+| --- | --- | --- |
+| 1 — Delete row | ~½ day | Trash icon, confirm dialog, `delete_order` command, tests. |
+| 2 — Merge orders | ~1.5 days | Migration, `merge_orders` command, sync changes, list filter, UI toolbar, confirm dialogs, tests. |
+
+Phases ship independently. Phase 1 has no dependency on Phase 2.

--- a/installers/macos/READ ME FIRST.txt
+++ b/installers/macos/READ ME FIRST.txt
@@ -1,0 +1,55 @@
+GRANNY'S POS — HOW TO INSTALL
+=============================
+
+STEP 1 — Install the app
+------------------------
+
+  1. Drag "Granny's POS" onto the Applications folder icon
+     (the arrow points the way).
+  2. Eject this disk: right-click the disk icon on your
+     desktop and choose "Eject".
+
+
+STEP 2 — First time you open it
+-------------------------------
+
+The first time only, macOS will block the app because it
+isn't from the App Store. This is normal. Do these steps
+once and you'll never see it again:
+
+  1. Open the Applications folder and double-click
+     "Granny's POS".
+
+  2. A warning will appear:
+       "Granny's POS Not Opened — Apple could not verify
+        Granny's POS is free of malware..."
+     Click "Done".
+
+  3. Open System Settings:
+       Apple menu (top-left)  →  System Settings...
+     OR
+       Click the gear icon in the Dock.
+
+  4. In the sidebar, click "Privacy & Security".
+
+  5. Scroll all the way down to the "Security" section.
+     You'll see this message:
+       "Granny's POS was blocked to protect your Mac."
+     Click the "Open Anyway" button next to it.
+
+  6. Enter your Mac password if it asks for it.
+
+  7. Go back to the Applications folder and double-click
+     "Granny's POS" again.
+     This time a new dialog appears with an "Open" button.
+     Click "Open".
+
+
+DONE!
+-----
+
+From now on, double-clicking the app icon opens it normally.
+You only do these steps the very first time.
+
+
+Need help? Ask the person who sent you this app.

--- a/src-tauri/src/commands/orders.rs
+++ b/src-tauri/src/commands/orders.rs
@@ -24,6 +24,8 @@ pub struct OrderListRow {
     pub notes: Option<String>,
     pub items_summary: String,
     pub sync_locked: bool,
+    pub merged_into_id: Option<String>,
+    pub merged_from_count: i64,
 }
 
 #[derive(Debug, Serialize)]
@@ -55,6 +57,8 @@ pub struct OrderDetail {
     pub print_count: i64,
     pub deleted_at: Option<String>,
     pub sync_locked: bool,
+    pub merged_into_id: Option<String>,
+    pub merged_from_count: i64,
     pub items: Vec<OrderDetailItem>,
 }
 
@@ -98,6 +102,9 @@ pub async fn list_orders(
         let items_summary = items.iter()
             .map(|(n, q)| format!("{}×{}", n, q))
             .collect::<Vec<_>>().join(" ");
+        let merged_from_count: (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
+        ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
         out.push(OrderListRow {
             id: r.id, order_number: r.order_number, customer_name: cust,
             channel: r.channel, delivery_location: r.delivery_location,
@@ -107,6 +114,8 @@ pub async fn list_orders(
             deleted_at: r.deleted_at, order_date: r.order_date,
             notes: r.notes, items_summary,
             sync_locked: r.sync_locked != 0,
+            merged_into_id: r.merged_into_id,
+            merged_from_count: merged_from_count.0,
         });
     }
     Ok(out)
@@ -132,6 +141,9 @@ pub async fn get_order(
             quantity: it.quantity, unit_price: it.unit_price,
         });
     }
+    let merged_from_count: (i64,) = sqlx::query_as(
+        r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
+    ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
     Ok(Some(OrderDetail {
         id: r.id, order_number: r.order_number, customer_name: cust,
         channel: r.channel, delivery_location: r.delivery_location,
@@ -140,6 +152,8 @@ pub async fn get_order(
         order_date: r.order_date, source_tab: r.source_tab, source_row: r.source_row,
         printed_at: r.printed_at, print_count: r.print_count,
         deleted_at: r.deleted_at, sync_locked: r.sync_locked != 0,
+        merged_into_id: r.merged_into_id,
+        merged_from_count: merged_from_count.0,
         items: detail_items,
     }))
 }
@@ -215,4 +229,25 @@ pub async fn delete_order(
     id: String,
 ) -> Result<(), String> {
     orders::delete_order(&state.db, &id).await.map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeResult {
+    pub master_order_id: String,
+    pub master_order_number: String,
+    pub merged_count: usize,
+}
+
+#[tauri::command]
+pub async fn merge_orders(
+    state: State<'_, AppState>,
+    order_ids: Vec<String>,
+) -> Result<MergeResult, String> {
+    let out = orders::merge_orders(&state.db, &order_ids).await.map_err(|e| e.to_string())?;
+    Ok(MergeResult {
+        master_order_id: out.master_order_id,
+        master_order_number: out.master_order_number,
+        merged_count: out.merged_count,
+    })
 }

--- a/src-tauri/src/commands/orders.rs
+++ b/src-tauri/src/commands/orders.rs
@@ -208,3 +208,11 @@ pub async fn print_order(
     orders::mark_printed(&state.db, &id).await.map_err(|e| e.to_string())?;
     Ok("Printed".into())
 }
+
+#[tauri::command]
+pub async fn delete_order(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<(), String> {
+    orders::delete_order(&state.db, &id).await.map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/orders.rs
+++ b/src-tauri/src/commands/orders.rs
@@ -25,6 +25,7 @@ pub struct OrderListRow {
     pub items_summary: String,
     pub sync_locked: bool,
     pub merged_into_id: Option<String>,
+    pub merged_into_order_number: Option<String>,
     pub merged_from_count: i64,
 }
 
@@ -58,6 +59,7 @@ pub struct OrderDetail {
     pub deleted_at: Option<String>,
     pub sync_locked: bool,
     pub merged_into_id: Option<String>,
+    pub merged_into_order_number: Option<String>,
     pub merged_from_count: i64,
     pub items: Vec<OrderDetailItem>,
 }
@@ -105,6 +107,12 @@ pub async fn list_orders(
         let merged_from_count: (i64,) = sqlx::query_as(
             r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
         ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
+        let merged_into_order_number: Option<String> = if let Some(ref mid) = r.merged_into_id {
+            let row: Option<(String,)> = sqlx::query_as(
+                r#"SELECT order_number FROM "order" WHERE id = ?"#,
+            ).bind(mid).fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
+            row.map(|t| t.0)
+        } else { None };
         out.push(OrderListRow {
             id: r.id, order_number: r.order_number, customer_name: cust,
             channel: r.channel, delivery_location: r.delivery_location,
@@ -115,6 +123,7 @@ pub async fn list_orders(
             notes: r.notes, items_summary,
             sync_locked: r.sync_locked != 0,
             merged_into_id: r.merged_into_id,
+            merged_into_order_number,
             merged_from_count: merged_from_count.0,
         });
     }
@@ -144,6 +153,12 @@ pub async fn get_order(
     let merged_from_count: (i64,) = sqlx::query_as(
         r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
     ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
+    let merged_into_order_number: Option<String> = if let Some(ref mid) = r.merged_into_id {
+        let row: Option<(String,)> = sqlx::query_as(
+            r#"SELECT order_number FROM "order" WHERE id = ?"#,
+        ).bind(mid).fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
+        row.map(|t| t.0)
+    } else { None };
     Ok(Some(OrderDetail {
         id: r.id, order_number: r.order_number, customer_name: cust,
         channel: r.channel, delivery_location: r.delivery_location,
@@ -153,6 +168,7 @@ pub async fn get_order(
         printed_at: r.printed_at, print_count: r.print_count,
         deleted_at: r.deleted_at, sync_locked: r.sync_locked != 0,
         merged_into_id: r.merged_into_id,
+        merged_into_order_number,
         merged_from_count: merged_from_count.0,
         items: detail_items,
     }))

--- a/src-tauri/src/db/migrations/0003_merge_orders.sql
+++ b/src-tauri/src/db/migrations/0003_merge_orders.sql
@@ -1,0 +1,18 @@
+-- Merge-orders feature.
+--
+-- merged_into_id: when set, this order has been folded into another order
+-- (the master). The donor row is also soft-deleted (deleted_at set) and is
+-- treated as "not a real order" for everything except sync.
+ALTER TABLE "order" ADD COLUMN merged_into_id TEXT
+    REFERENCES "order"(id);
+CREATE INDEX idx_order_merged_into ON "order"(merged_into_id);
+
+-- order_item.source_row: which sheet row produced this item. For non-merged
+-- orders this matches the parent order's source_row. For merged masters the
+-- master holds items from multiple source_rows; sync uses this tag to refresh
+-- only the items that belong to the row currently being parsed.
+ALTER TABLE order_item ADD COLUMN source_row INTEGER;
+UPDATE order_item
+   SET source_row = (
+     SELECT source_row FROM "order" WHERE "order".id = order_item.order_id
+   );

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -139,21 +139,27 @@ pub async fn upsert_from_source(
     };
 
     // Locked rows keep their items as-is. Refresh them only when the row is
-    // either brand new or being updated from the sheet.
+    // either brand new or being updated from the sheet, AND only for items
+    // tagged with this sheet row. Other source_rows' items stay (the merge
+    // feature relies on this: a master order holds items from multiple
+    // source_rows).
     let is_locked: (i64,) = sqlx::query_as(
         r#"SELECT sync_locked FROM "order" WHERE id = ?"#,
     )
     .bind(&order_id).fetch_one(&mut **tx).await?;
     if is_locked.0 == 0 {
-        sqlx::query(r#"DELETE FROM order_item WHERE order_id = ?"#)
-            .bind(&order_id).execute(&mut **tx).await?;
+        sqlx::query(
+            r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+        )
+        .bind(&order_id).bind(input.source_row).execute(&mut **tx).await?;
         for item in input.items {
             sqlx::query(
-                r#"INSERT INTO order_item (id, order_id, product_id, quantity, unit_price)
-                   VALUES (?, ?, ?, ?, ?)"#,
+                r#"INSERT INTO order_item
+                   (id, order_id, product_id, quantity, unit_price, source_row)
+                   VALUES (?, ?, ?, ?, ?, ?)"#,
             )
             .bind(new_id()).bind(&order_id).bind(item.product_id)
-            .bind(item.quantity).bind(item.unit_price)
+            .bind(item.quantity).bind(item.unit_price).bind(input.source_row)
             .execute(&mut **tx).await?;
         }
     }
@@ -640,6 +646,47 @@ mod tests {
         let err = delete_order(&pool, &out.order_id).await.unwrap_err();
         assert!(matches!(err, sqlx::Error::Protocol(_)),
             "expected Protocol error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn upsert_only_refreshes_items_tagged_with_its_source_row() {
+        // Simulates the post-merge state by hand: one order owns items tagged with
+        // two different source_rows. Re-running upsert for source_row=11 must only
+        // touch items tagged 11 and leave items tagged 12 alone.
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        let out = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // Hand-insert a second item on the same order tagged with source_row 12.
+        sqlx::query(
+            r#"INSERT INTO order_item (id, order_id, product_id, quantity, unit_price, source_row)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(new_id()).bind(&out.order_id).bind(&p.id).bind(3_i64).bind(85_i64).bind(12_i64)
+        .execute(&pool).await.unwrap();
+
+        // Re-upsert row 11 with a different quantity — row 12's item must survive.
+        let mut tx = pool.begin().await.unwrap();
+        upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 170, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 2, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let items: Vec<(i64, Option<i64>)> = sqlx::query_as(
+            r#"SELECT quantity, source_row FROM order_item WHERE order_id = ? ORDER BY source_row"#,
+        ).bind(&out.order_id).fetch_all(&pool).await.unwrap();
+        assert_eq!(items, vec![(2, Some(11)), (3, Some(12))]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -180,12 +180,14 @@ pub async fn soft_delete_missing_rows(
     // silently match nothing in SQLite, so drop that predicate entirely.
     let sql = if keep_rows.is_empty() {
         r#"UPDATE "order" SET deleted_at = ?, updated_at = ?
-           WHERE source_tab = ? AND deleted_at IS NULL AND sync_locked = 0"#.to_string()
+           WHERE source_tab = ? AND deleted_at IS NULL AND sync_locked = 0
+             AND merged_into_id IS NULL"#.to_string()
     } else {
         let placeholders = keep_rows.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         format!(
             r#"UPDATE "order" SET deleted_at = ?, updated_at = ?
                WHERE source_tab = ? AND deleted_at IS NULL AND sync_locked = 0
+                 AND merged_into_id IS NULL
                  AND source_row NOT IN ({})"#,
             placeholders
         )
@@ -204,6 +206,8 @@ pub async fn list_by_tab(
 ) -> Result<Vec<OrderRow>, sqlx::Error> {
     let mut sql = String::from(r#"SELECT * FROM "order" WHERE 1=1"#);
     if !include_deleted { sql.push_str(" AND deleted_at IS NULL"); }
+    // Merged-away rows are soft-deleted donors; show them only with include_deleted.
+    if !include_deleted { sql.push_str(" AND merged_into_id IS NULL"); }
     if tab.is_some() { sql.push_str(" AND source_tab = ?"); }
     sql.push_str(" ORDER BY source_tab DESC, source_row DESC LIMIT ?");
     let mut q = sqlx::query_as::<_, OrderRow>(&sql);
@@ -1015,5 +1019,62 @@ mod tests {
             .await.unwrap_err();
         assert!(matches!(err, sqlx::Error::Protocol(_)),
             "expected Protocol error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn list_hides_merged_away_rows_by_default() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+        let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+        assert_eq!(alive.len(), 1);
+        assert_eq!(alive[0].id, a.order_id);
+
+        let all = list_by_tab(&pool, Some("Order_30"), true, 100).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn soft_delete_missing_rows_skips_merged_away() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+        // Sheet sync says "only row 4 still exists". soft_delete_missing_rows must
+        // ignore row 5's order shell because it's already merged-away — touching
+        // it would re-stamp deleted_at unnecessarily.
+        let mut tx = pool.begin().await.unwrap();
+        let n = soft_delete_missing_rows(&mut tx, "Order_30", &[4]).await.unwrap();
+        tx.commit().await.unwrap();
+        assert_eq!(n, 0);
     }
 }

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -23,6 +23,7 @@ pub struct OrderRow {
     pub print_count: i64,
     pub deleted_at: Option<String>,
     pub sync_locked: i64,
+    pub merged_into_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -41,6 +42,7 @@ pub struct OrderItemRow {
     pub product_id: String,
     pub quantity: i64,
     pub unit_price: i64,
+    pub source_row: Option<i64>,
 }
 
 pub struct UpsertOrderInput<'a> {
@@ -638,5 +640,40 @@ mod tests {
         let err = delete_order(&pool, &out.order_id).await.unwrap_err();
         assert!(matches!(err, sqlx::Error::Protocol(_)),
             "expected Protocol error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn migration_0003_adds_columns_and_backfill_query_runs() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // The migration's backfill is retroactive — items inserted by code that
+        // doesn't yet set source_row will read NULL here. Run the same backfill
+        // query that the migration runs to prove the SQL is shaped right.
+        sqlx::query(
+            r#"UPDATE order_item
+                 SET source_row = (
+                   SELECT source_row FROM "order" WHERE "order".id = order_item.order_id
+                 )
+               WHERE source_row IS NULL"#,
+        ).execute(&pool).await.unwrap();
+
+        let row: (Option<i64>,) = sqlx::query_as(
+            r#"SELECT source_row FROM order_item LIMIT 1"#,
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(row.0, Some(11), "backfill should populate source_row from parent order");
+
+        // Confirm the merged_into_id column exists on "order".
+        let _: (Option<String>,) = sqlx::query_as(
+            r#"SELECT merged_into_id FROM "order" LIMIT 1"#,
+        ).fetch_one(&pool).await.unwrap();
     }
 }

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -335,7 +335,6 @@ pub async fn delete_order(pool: &SqlitePool, order_id: &str) -> Result<(), sqlx:
     Ok(())
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct MergeOutcome {
     pub master_order_id: String,
@@ -354,7 +353,6 @@ pub struct MergeOutcome {
 ///   * No order may already be merged-away (`merged_into_id IS NOT NULL`).
 ///   * No order may be `sync_locked` (manual override; merge would replace it).
 ///   * No order may be soft-deleted.
-#[allow(dead_code)]
 pub async fn merge_orders(
     pool: &SqlitePool,
     order_ids: &[String],

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -197,7 +197,7 @@ pub async fn list_by_tab(
     let mut sql = String::from(r#"SELECT * FROM "order" WHERE 1=1"#);
     if !include_deleted { sql.push_str(" AND deleted_at IS NULL"); }
     if tab.is_some() { sql.push_str(" AND source_tab = ?"); }
-    sql.push_str(" ORDER BY source_tab DESC, source_row ASC LIMIT ?");
+    sql.push_str(" ORDER BY source_tab DESC, source_row DESC LIMIT ?");
     let mut q = sqlx::query_as::<_, OrderRow>(&sql);
     if let Some(t) = tab { q = q.bind(t); }
     q = q.bind(limit);
@@ -288,6 +288,38 @@ pub async fn upsert_week_mapping(
            ON CONFLICT(tab_name) DO UPDATE SET week_start_date = excluded.week_start_date"#,
     )
     .bind(tab).bind(week_start).execute(pool).await?;
+    Ok(())
+}
+
+/// Soft-delete an order and lock it against re-sync.
+///
+/// Returns an error if the order doesn't exist or is already soft-deleted.
+/// The lock is what stops the next `apply_sync` from inserting the row again.
+/// A future task adds an additional guard against deleting a row that's been
+/// merged into another order.
+pub async fn delete_order(pool: &SqlitePool, order_id: &str) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let row: Option<(Option<String>,)> = sqlx::query_as(
+        r#"SELECT deleted_at FROM "order" WHERE id = ?"#,
+    )
+    .bind(order_id).fetch_optional(&mut *tx).await?;
+    let Some((deleted_at,)) = row else {
+        return Err(sqlx::Error::RowNotFound);
+    };
+    if deleted_at.is_some() {
+        return Err(sqlx::Error::Protocol(
+            format!("order {} is already deleted", order_id).into()
+        ));
+    }
+    let now = now_iso();
+    sqlx::query(
+        r#"UPDATE "order" SET deleted_at = ?, sync_locked = 1, updated_at = ?
+           WHERE id = ?"#,
+    )
+    .bind(&now).bind(&now).bind(order_id)
+    .execute(&mut *tx).await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -546,5 +578,65 @@ mod tests {
             "order_numbers should all be unique, got: {:?}", nums);
         assert_eq!(nums[0], "16-17/05/26-1");
         assert_eq!(nums[9], "16-17/05/26-10");
+    }
+
+    #[tokio::test]
+    async fn delete_order_soft_deletes_and_locks_against_resync() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+
+        // Insert via the normal sync path so the row mirrors a real sheet row.
+        let mut tx = pool.begin().await.unwrap();
+        let out = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None,
+            delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        delete_order(&pool, &out.order_id).await.unwrap();
+
+        // Hidden by default
+        let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+        assert_eq!(alive.len(), 0);
+        // Visible under include_deleted
+        let all = list_by_tab(&pool, Some("Order_30"), true, 100).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].deleted_at.is_some());
+        assert_eq!(all[0].sync_locked, 1);
+
+        // Re-syncing the same row must NOT resurrect it (sync_locked guards both
+        // upsert_from_source and soft_delete_missing_rows).
+        let mut tx = pool.begin().await.unwrap();
+        upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None,
+            delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        let alive = list_by_tab(&pool, Some("Order_30"), false, 100).await.unwrap();
+        assert_eq!(alive.len(), 0, "deleted+locked row must stay hidden after re-sync");
+    }
+
+    #[tokio::test]
+    async fn delete_order_rejects_already_deleted() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let out = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 11,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        delete_order(&pool, &out.order_id).await.unwrap();
+        let err = delete_order(&pool, &out.order_id).await.unwrap_err();
+        assert!(matches!(err, sqlx::Error::Protocol(_)),
+            "expected Protocol error, got {:?}", err);
     }
 }

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -331,6 +331,129 @@ pub async fn delete_order(pool: &SqlitePool, order_id: &str) -> Result<(), sqlx:
     Ok(())
 }
 
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct MergeOutcome {
+    pub master_order_id: String,
+    pub master_order_number: String,
+    pub merged_count: usize,
+}
+
+/// Merge `order_ids` into one master order. The master is the input order
+/// with the smallest `source_row`. Donor orders are soft-deleted and their
+/// `merged_into_id` points at the master; their items move onto the master,
+/// tagged with the donor's `source_row`. Discount and delivery_fee are summed.
+///
+/// Constraints:
+///   * 2+ ids required.
+///   * All orders must share the same `source_tab`.
+///   * No order may already be merged-away (`merged_into_id IS NOT NULL`).
+///   * No order may be `sync_locked` (manual override; merge would replace it).
+///   * No order may be soft-deleted.
+#[allow(dead_code)]
+pub async fn merge_orders(
+    pool: &SqlitePool,
+    order_ids: &[String],
+) -> Result<MergeOutcome, sqlx::Error> {
+    if order_ids.len() < 2 {
+        return Err(sqlx::Error::Protocol(
+            "merge requires at least two orders".into(),
+        ));
+    }
+    let mut rows: Vec<OrderRow> = Vec::with_capacity(order_ids.len());
+    for id in order_ids {
+        let row = sqlx::query_as::<_, OrderRow>(
+            r#"SELECT * FROM "order" WHERE id = ?"#,
+        ).bind(id).fetch_optional(pool).await?
+        .ok_or(sqlx::Error::RowNotFound)?;
+        rows.push(row);
+    }
+    // Constraint checks.
+    let tab = rows[0].source_tab.clone();
+    for r in &rows {
+        if r.source_tab.is_none() {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} has no source_tab; cannot be merged", r.order_number).into()
+            ));
+        }
+        if r.source_tab != tab {
+            return Err(sqlx::Error::Protocol(
+                "all orders must share the same source_tab".into()
+            ));
+        }
+        if r.merged_into_id.is_some() {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} is already merged into another", r.order_number).into()
+            ));
+        }
+        if r.sync_locked != 0 {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} has manual edits; unlock before merging", r.order_number).into()
+            ));
+        }
+        if r.deleted_at.is_some() {
+            return Err(sqlx::Error::Protocol(
+                format!("order {} is removed", r.order_number).into()
+            ));
+        }
+    }
+
+    // Master = lowest source_row.
+    rows.sort_by_key(|r| r.source_row.unwrap_or(i64::MAX));
+    let master = rows.remove(0);
+    let donors = rows;
+    let now = now_iso();
+
+    let mut tx = pool.begin().await?;
+
+    // Move each donor's items onto the master, tagged with the donor's source_row.
+    let mut summed_discount = master.discount;
+    let mut summed_delivery = master.delivery_fee;
+    for d in &donors {
+        let donor_row = d.source_row.unwrap_or(0);
+        sqlx::query(
+            r#"UPDATE order_item
+               SET order_id = ?, source_row = ?
+               WHERE order_id = ?"#,
+        )
+        .bind(&master.id).bind(donor_row).bind(&d.id)
+        .execute(&mut *tx).await?;
+
+        summed_discount += d.discount;
+        summed_delivery += d.delivery_fee;
+
+        sqlx::query(
+            r#"UPDATE "order" SET
+                 merged_into_id = ?, deleted_at = ?, sync_locked = 0, updated_at = ?
+               WHERE id = ?"#,
+        )
+        .bind(&master.id).bind(&now).bind(&now).bind(&d.id)
+        .execute(&mut *tx).await?;
+    }
+
+    // Recompute master total = subtotal - discount + delivery_fee.
+    let subtotal: (i64,) = sqlx::query_as(
+        r#"SELECT COALESCE(SUM(quantity * unit_price), 0) FROM order_item WHERE order_id = ?"#,
+    ).bind(&master.id).fetch_one(&mut *tx).await?;
+    let new_total = (subtotal.0 - summed_discount + summed_delivery).max(0);
+
+    sqlx::query(
+        r#"UPDATE "order" SET
+             total_amount = ?, discount = ?, delivery_fee = ?, updated_at = ?
+           WHERE id = ?"#,
+    )
+    .bind(new_total).bind(summed_discount).bind(summed_delivery).bind(&now).bind(&master.id)
+    .execute(&mut *tx).await?;
+
+    tx.commit().await?;
+
+    Ok(MergeOutcome {
+        master_order_id: master.id,
+        master_order_number: master.order_number,
+        merged_count: donors.len(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -722,5 +845,175 @@ mod tests {
         let _: (Option<String>,) = sqlx::query_as(
             r#"SELECT merged_into_id FROM "order" LIMIT 1"#,
         ).fetch_one(&pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn merge_two_orders_moves_items_sums_fees_marks_donor() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 170, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 2, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // Give B a delivery fee so we can confirm the sum.
+        sqlx::query(
+            r#"UPDATE "order" SET delivery_fee = 40, total_amount = total_amount + 40 WHERE id = ?"#,
+        ).bind(&b.order_id).execute(&pool).await.unwrap();
+
+        let out = merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+        // Master = lowest source_row (row 4)
+        assert_eq!(out.master_order_id, a.order_id);
+        assert_eq!(out.merged_count, 1);
+
+        let (master, items) = get_with_items(&pool, &a.order_id).await.unwrap().unwrap();
+        assert_eq!(master.delivery_fee, 40);
+        assert_eq!(master.discount, 0);
+        // 1×85 (row 4) + 2×85 (row 5) + 40 fee = 295
+        assert_eq!(master.total_amount, 295);
+        assert!(master.merged_into_id.is_none());
+        assert_eq!(master.sync_locked, 0, "merge must NOT lock the master");
+        assert_eq!(items.len(), 2);
+
+        let donor = sqlx::query_as::<_, OrderRow>(r#"SELECT * FROM "order" WHERE id = ?"#)
+            .bind(&b.order_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(donor.merged_into_id.as_deref(), Some(a.order_id.as_str()));
+        assert!(donor.deleted_at.is_some());
+        assert_eq!(donor.sync_locked, 0);
+    }
+
+    #[tokio::test]
+    async fn merge_rejects_cross_tab() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-18",
+            source_tab: "Order_31", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        let err = merge_orders(&pool, &[a.order_id, b.order_id]).await.unwrap_err();
+        assert!(matches!(err, sqlx::Error::Protocol(_)),
+            "expected Protocol error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn merge_rejects_locked_donor() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        apply_order_edit(&pool, &b.order_id, &[
+            EditOrderItem { product_id: p.id.clone(), quantity: 1, unit_price: 85 },
+        ], 0, 0).await.unwrap();
+        let err = merge_orders(&pool, &[a.order_id, b.order_id]).await.unwrap_err();
+        assert!(matches!(err, sqlx::Error::Protocol(_)),
+            "expected Protocol error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn merge_into_existing_master_succeeds() {
+        // After a successful merge, the master order remains a valid merge target
+        // — merging another order into it stacks more donors onto the same master.
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let cc = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 6,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // First merge: a becomes master, b is merged away.
+        merge_orders(&pool, &[a.order_id.clone(), b.order_id]).await.unwrap();
+
+        // Second merge: a is still master (not merged-away), cc is a fresh donor — must succeed.
+        let res = merge_orders(&pool, &[a.order_id.clone(), cc.order_id]).await;
+        assert!(res.is_ok(), "merging into an existing master must work");
+
+        // a should still be master after the second merge.
+        let (master, _) = get_with_items(&pool, &a.order_id).await.unwrap().unwrap();
+        assert!(master.merged_into_id.is_none(), "a must still be master after second merge");
+    }
+
+    #[tokio::test]
+    async fn merge_rejects_already_merged() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        let cc = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 6,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // First merge: a is master, b becomes merged-away.
+        merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+        // Attempting to merge the already-merged donor (b) again must reject.
+        let err = merge_orders(&pool, &[b.order_id.clone(), cc.order_id.clone()])
+            .await.unwrap_err();
+        assert!(matches!(err, sqlx::Error::Protocol(_)),
+            "expected Protocol error, got {:?}", err);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             commands::orders::get_order,
             commands::orders::print_order,
             commands::orders::update_order,
+            commands::orders::delete_order,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
             commands::orders::print_order,
             commands::orders::update_order,
             commands::orders::delete_order,
+            commands::orders::merge_orders,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -72,10 +72,14 @@ pub async fn preview_sync(
         }
     }
 
-    // Count insert/update/soft-delete
+    // Count insert/update/soft-delete.
+    // Existing rows includes merged-away donors. We treat them as "exists"
+    // so the preview counters categorize sheet edits to them as updates,
+    // not inserts.
     let existing: Vec<(i64,)> = sqlx::query_as(
         r#"SELECT source_row FROM "order"
-           WHERE source_tab = ? AND deleted_at IS NULL"#,
+           WHERE source_tab = ?
+             AND (deleted_at IS NULL OR merged_into_id IS NOT NULL)"#,
     )
     .bind(tab).fetch_all(pool).await?;
     let existing_rows: std::collections::HashSet<i64> = existing.into_iter().map(|t| t.0).collect();
@@ -192,6 +196,8 @@ pub async fn apply_sync(
     let mut added = 0i64;
     let mut updated = 0i64;
     let mut keep_rows: Vec<i64> = Vec::new();
+    let mut masters_to_recompute: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     for ord in &preview.parsed_orders {
         let cust_id = customer_alias_to_id.get(&ord.customer)
             .ok_or_else(|| anyhow!("Unresolved customer {}", ord.customer))?.clone();
@@ -206,6 +212,37 @@ pub async fn apply_sync(
             let unit = *product_price_by_id.get(&pid).unwrap_or(&0);
             total += unit * item.quantity;
             item_data.push((pid, item.quantity, unit));
+        }
+
+        // Pull-through path: if this row was merged into another order, refresh
+        // the master's items tagged with this row's source_row instead of doing
+        // the normal upsert (which would resurrect the donor's order shell).
+        let donor_master: Option<String> = sqlx::query_as::<_, (Option<String>,)>(
+            r#"SELECT merged_into_id FROM "order" WHERE source_tab = ? AND source_row = ?"#,
+        )
+        .bind(tab).bind(ord.source_row)
+        .fetch_optional(&mut *tx).await?
+        .and_then(|(m,)| m);
+
+        if let Some(master_id) = donor_master {
+            sqlx::query(
+                r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+            )
+            .bind(&master_id).bind(ord.source_row).execute(&mut *tx).await?;
+            for (pid, qty, unit) in &item_data {
+                sqlx::query(
+                    r#"INSERT INTO order_item
+                       (id, order_id, product_id, quantity, unit_price, source_row)
+                       VALUES (?, ?, ?, ?, ?, ?)"#,
+                )
+                .bind(crate::db::ids::new_id())
+                .bind(&master_id).bind(pid).bind(qty).bind(unit).bind(ord.source_row)
+                .execute(&mut *tx).await?;
+            }
+            masters_to_recompute.insert(master_id);
+            keep_rows.push(ord.source_row);
+            updated += 1;
+            continue;
         }
 
         let items: Vec<orders::UpsertOrderItemInput<'_>> = item_data.iter().map(|(pid, qty, unit)| {
@@ -231,6 +268,44 @@ pub async fn apply_sync(
         keep_rows.push(ord.source_row);
     }
     let soft_deleted = orders::soft_delete_missing_rows(&mut tx, tab, &keep_rows).await?;
+
+    // If a donor row vanished from the sheet, its items must vanish from the
+    // master too. soft_delete_missing_rows skips merged-away rows, so we
+    // detect them here and strip their items.
+    let stale_donors: Vec<(String, i64)> = sqlx::query_as(
+        r#"SELECT merged_into_id, source_row FROM "order"
+           WHERE source_tab = ?
+             AND merged_into_id IS NOT NULL
+             AND source_row IS NOT NULL"#,
+    ).bind(tab).fetch_all(&mut *tx).await?;
+    for (master_id, row) in stale_donors {
+        if !keep_rows.contains(&row) {
+            sqlx::query(
+                r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
+            )
+            .bind(&master_id).bind(row).execute(&mut *tx).await?;
+            masters_to_recompute.insert(master_id);
+        }
+    }
+
+    // Recompute totals for any master that changed.
+    for master_id in &masters_to_recompute {
+        let row: (i64, i64, i64) = sqlx::query_as(
+            r#"SELECT
+                 COALESCE(SUM(oi.quantity * oi.unit_price), 0) AS subtotal,
+                 o.discount, o.delivery_fee
+               FROM "order" o
+               LEFT JOIN order_item oi ON oi.order_id = o.id
+               WHERE o.id = ?
+               GROUP BY o.id"#,
+        ).bind(master_id).fetch_one(&mut *tx).await?;
+        let new_total = (row.0 - row.1 + row.2).max(0);
+        sqlx::query(
+            r#"UPDATE "order" SET total_amount = ?, updated_at = ? WHERE id = ?"#,
+        ).bind(new_total).bind(crate::db::ids::now_iso()).bind(master_id)
+        .execute(&mut *tx).await?;
+    }
+
     tx.commit().await?;
 
     orders::upsert_week_mapping(pool, tab, &preview.week_start_date).await?;
@@ -409,6 +484,117 @@ mod tests {
         let full = crate::db::products::find_by_alias(&pool, "FullName").await.unwrap().unwrap();
         let short = crate::db::products::find_by_alias(&pool, "Short").await.unwrap().unwrap();
         assert_eq!(full.id, short.id);
+    }
+
+    #[tokio::test]
+    async fn merged_donor_row_edits_flow_into_master() {
+        use crate::db::orders::{merge_orders, get_with_items};
+
+        let pool = init_memory_pool().await.unwrap();
+        let tab = "Order_30";
+        // Both Choc and Matcha in the top menu with proper prices.
+        // Layout (0-indexed):
+        //   0: Choc   menu item  (price at col4 = 100)
+        //   1: Matcha menu item  (price at col4 = 120)
+        //   2: blank  → stops menu loop
+        //   3: ช่องทาง header
+        //   4: K.Ing Choc row   → source_row = 5
+        //   5: K.Ing Matcha row → source_row = 6
+        let make_sheet = |row6_qty: &str| {
+            make_vr(vec![
+                vec!["Choc",   "", "", "", "100"],
+                vec!["Matcha", "", "", "", "120"],
+                vec![""],
+                vec!["ช่องทาง", "ลูกค้า", "Choc", "Matcha"],
+                vec!["Page", "K.Ing", "1", ""],
+                vec!["Page", "K.Ing", "", row6_qty],
+            ])
+        };
+        let fake = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("1"))]),
+        };
+        let preview = preview_sync(&pool, &fake, "x", tab).await.unwrap();
+        let mappings = SyncMappings {
+            menu: preview.unknown_menus.iter().map(|m| (m.alias.clone(),
+                MenuMappingChoice::Create { name_th: m.alias.clone(), name_en: None, selling_price: m.suggested_price })).collect(),
+            customer: preview.unknown_customers.iter().map(|c| (c.alias.clone(),
+                CustomerMappingChoice::Create { name: c.alias.clone() })).collect(),
+        };
+        apply_sync(&pool, &fake, "x", tab, mappings).await.unwrap();
+
+        // Merge the two K.Ing rows.
+        let orders = crate::db::orders::list_by_tab(&pool, Some(tab), false, 100).await.unwrap();
+        assert_eq!(orders.len(), 2);
+        let ids: Vec<String> = orders.iter().map(|o| o.id.clone()).collect();
+        let merged = merge_orders(&pool, &ids).await.unwrap();
+
+        // Wife edits the Matcha row (source_row=6) to qty=3.
+        let fake2 = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("3"))]),
+        };
+        apply_sync(&pool, &fake2, "x", tab, SyncMappings { menu: vec![], customer: vec![] }).await.unwrap();
+
+        // Master now reflects qty=3 for source_row=6; qty=1 for source_row=5 still.
+        let (master, items) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+        let row5 = items.iter().find(|i| i.source_row == Some(5)).expect("row 5 item");
+        let row6 = items.iter().find(|i| i.source_row == Some(6)).expect("row 6 item");
+        assert_eq!(row5.quantity, 1);
+        assert_eq!(row6.quantity, 3);
+        // Total = 100*1 + 120*3 = 460
+        assert_eq!(master.total_amount, 460);
+    }
+
+    #[tokio::test]
+    async fn merged_donor_row_removed_from_sheet_strips_its_items_from_master() {
+        use crate::db::orders::{merge_orders, get_with_items};
+
+        let pool = init_memory_pool().await.unwrap();
+        let tab = "Order_32";
+        let two_rows = make_vr(vec![
+            vec!["Choc",   "", "", "", "100"],
+            vec!["Matcha", "", "", "", "120"],
+            vec![""],
+            vec!["ช่องทาง", "ลูกค้า", "Choc", "Matcha"],
+            vec!["Page", "K.Ing", "1", ""],
+            vec!["Page", "K.Ing", "", "1"],
+        ]);
+        // source_rows: row4→5, row5→6
+        let fake = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), two_rows)]),
+        };
+        let p = preview_sync(&pool, &fake, "x", tab).await.unwrap();
+        apply_sync(&pool, &fake, "x", tab, SyncMappings {
+            menu: p.unknown_menus.iter().map(|m| (m.alias.clone(),
+                MenuMappingChoice::Create { name_th: m.alias.clone(), name_en: None, selling_price: m.suggested_price })).collect(),
+            customer: p.unknown_customers.iter().map(|c| (c.alias.clone(),
+                CustomerMappingChoice::Create { name: c.alias.clone() })).collect(),
+        }).await.unwrap();
+
+        let orders = crate::db::orders::list_by_tab(&pool, Some(tab), false, 100).await.unwrap();
+        let ids: Vec<String> = orders.iter().map(|o| o.id.clone()).collect();
+        let merged = merge_orders(&pool, &ids).await.unwrap();
+
+        // Sheet drops the second K.Ing row (source_row=6).
+        let one_row = make_vr(vec![
+            vec!["Choc",   "", "", "", "100"],
+            vec!["Matcha", "", "", "", "120"],
+            vec![""],
+            vec!["ช่องทาง", "ลูกค้า", "Choc", "Matcha"],
+            vec!["Page", "K.Ing", "1", ""],
+        ]);
+        let fake2 = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), one_row)]),
+        };
+        apply_sync(&pool, &fake2, "x", tab, SyncMappings { menu: vec![], customer: vec![] }).await.unwrap();
+
+        let (master, items) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+        assert_eq!(items.len(), 1, "row 6's item must be gone");
+        assert_eq!(items[0].source_row, Some(5));
+        assert_eq!(master.total_amount, 100);
     }
 
     #[tokio::test]

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -225,6 +225,17 @@ pub async fn apply_sync(
         .and_then(|(m,)| m);
 
         if let Some(master_id) = donor_master {
+            // Locked master: cashier has manually edited it via EditOrderDialog;
+            // don't overwrite their edits with sheet data.
+            let master_locked: (i64,) = sqlx::query_as(
+                r#"SELECT sync_locked FROM "order" WHERE id = ?"#,
+            )
+            .bind(&master_id).fetch_one(&mut *tx).await?;
+            if master_locked.0 != 0 {
+                keep_rows.push(ord.source_row);
+                continue;
+            }
+
             sqlx::query(
                 r#"DELETE FROM order_item WHERE order_id = ? AND source_row = ?"#,
             )
@@ -595,6 +606,63 @@ mod tests {
         assert_eq!(items.len(), 1, "row 6's item must be gone");
         assert_eq!(items[0].source_row, Some(5));
         assert_eq!(master.total_amount, 100);
+    }
+
+    #[tokio::test]
+    async fn locked_master_ignores_donor_row_edits_via_sync() {
+        use crate::db::orders::{merge_orders, apply_order_edit, get_with_items, EditOrderItem};
+
+        let pool = init_memory_pool().await.unwrap();
+        let tab = "Order_31";
+        // Use the same fixture format as merged_donor_row_edits_flow_into_master.
+        let make_sheet = |row6_qty: &str| {
+            make_vr(vec![
+                vec!["Choc",   "", "", "", "100"],
+                vec!["Matcha", "", "", "", "120"],
+                vec![""],
+                vec!["ช่องทาง", "ลูกค้า", "Choc", "Matcha"],
+                vec!["Page", "K.Ing", "1", ""],
+                vec!["Page", "K.Ing", "", row6_qty],
+            ])
+        };
+        let fake = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("1"))]),
+        };
+        let preview = preview_sync(&pool, &fake, "x", tab).await.unwrap();
+        apply_sync(&pool, &fake, "x", tab, SyncMappings {
+            menu: preview.unknown_menus.iter().map(|m| (m.alias.clone(),
+                MenuMappingChoice::Create { name_th: m.alias.clone(), name_en: None, selling_price: m.suggested_price })).collect(),
+            customer: preview.unknown_customers.iter().map(|c| (c.alias.clone(),
+                CustomerMappingChoice::Create { name: c.alias.clone() })).collect(),
+        }).await.unwrap();
+
+        // Merge the two K.Ing rows, then lock the master via apply_order_edit.
+        let orders = crate::db::orders::list_by_tab(&pool, Some(tab), false, 100).await.unwrap();
+        let ids: Vec<String> = orders.iter().map(|o| o.id.clone()).collect();
+        let merged = merge_orders(&pool, &ids).await.unwrap();
+        let (master_before, items_before) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+        let total_before = master_before.total_amount;
+        let item_count_before = items_before.len();
+
+        // Cashier edits the master in-app — keep items as-is but trigger the lock.
+        let edit_items: Vec<EditOrderItem> = items_before.iter().map(|it| EditOrderItem {
+            product_id: it.product_id.clone(),
+            quantity: it.quantity,
+            unit_price: it.unit_price,
+        }).collect();
+        apply_order_edit(&pool, &merged.master_order_id, &edit_items, 0, 0).await.unwrap();
+
+        // Sheet edits the Matcha row (source_row=6) to qty=3 — locked master must ignore.
+        let fake2 = FakeSheetsClient {
+            tabs: vec![tab.to_string()],
+            values: HashMap::from([(format!("{}!A1:Z200", tab), make_sheet("3"))]),
+        };
+        apply_sync(&pool, &fake2, "x", tab, SyncMappings { menu: vec![], customer: vec![] }).await.unwrap();
+
+        let (master_after, items_after) = get_with_items(&pool, &merged.master_order_id).await.unwrap().unwrap();
+        assert_eq!(master_after.total_amount, total_before, "locked master total must not change from sync");
+        assert_eq!(items_after.len(), item_count_before, "locked master items must not change from sync");
     }
 
     #[tokio::test]

--- a/src/components/EditOrderDialog.test.tsx
+++ b/src/components/EditOrderDialog.test.tsx
@@ -43,6 +43,8 @@ const baseDetail: OrderDetail = {
     { productId: 'p1', nameTh: 'ก๋วยเตี๋ยว', quantity: 2, unitPrice: 100 },
     { productId: 'p2', nameTh: 'ชาเย็น', quantity: 1, unitPrice: 50 },
   ],
+  mergedIntoId: null,
+  mergedFromCount: 0,
 };
 
 const detailWithFreeItem: OrderDetail = {

--- a/src/components/EditOrderDialog.test.tsx
+++ b/src/components/EditOrderDialog.test.tsx
@@ -44,6 +44,7 @@ const baseDetail: OrderDetail = {
     { productId: 'p2', nameTh: 'ชาเย็น', quantity: 1, unitPrice: 50 },
   ],
   mergedIntoId: null,
+  mergedIntoOrderNumber: null,
   mergedFromCount: 0,
 };
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -53,4 +53,5 @@ export const ordersApi = {
     invoke<string>('print_order', { config, id }),
   update: (id: string, payload: OrderEditPayload) =>
     invoke<void>('update_order', { id, payload }),
+  delete: (id: string) => invoke<void>('delete_order', { id }),
 };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type {
   AppConfig,
   CustomerLite,
+  MergeResult,
   OrderDetail,
   OrderEditPayload,
   OrderListRow,
@@ -54,4 +55,6 @@ export const ordersApi = {
   update: (id: string, payload: OrderEditPayload) =>
     invoke<void>('update_order', { id, payload }),
   delete: (id: string) => invoke<void>('delete_order', { id }),
+  merge: (orderIds: string[]) =>
+    invoke<MergeResult>('merge_orders', { orderIds }),
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,8 @@ export interface OrderListRow {
   notes: string | null;
   itemsSummary: string;
   syncLocked: boolean;
+  mergedIntoId: string | null;
+  mergedFromCount: number;
 }
 
 export interface OrderDetailItem {
@@ -80,6 +82,14 @@ export interface OrderDetail {
   deletedAt: string | null;
   syncLocked: boolean;
   items: OrderDetailItem[];
+  mergedIntoId: string | null;
+  mergedFromCount: number;
+}
+
+export interface MergeResult {
+  masterOrderId: string;
+  masterOrderNumber: string;
+  mergedCount: number;
 }
 
 export interface OrderEditItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,7 @@ export interface OrderListRow {
   itemsSummary: string;
   syncLocked: boolean;
   mergedIntoId: string | null;
+  mergedIntoOrderNumber: string | null;
   mergedFromCount: number;
 }
 
@@ -83,6 +84,7 @@ export interface OrderDetail {
   syncLocked: boolean;
   items: OrderDetailItem[];
   mergedIntoId: string | null;
+  mergedIntoOrderNumber: string | null;
   mergedFromCount: number;
 }
 

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -8,6 +8,7 @@ import {
   PencilLine,
   Printer,
   RefreshCw,
+  Trash2,
 } from 'lucide-react';
 import { ordersApi } from '../lib/tauri';
 import type { AppConfig, OrderDetail, OrderListRow } from '../lib/types';
@@ -23,6 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
 import { cn } from '../lib/cn';
 
 interface OrdersPageProps {
@@ -42,6 +51,8 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
   const [details, setDetails] = useState<Record<string, OrderDetail>>({});
   const [editing, setEditing] = useState<OrderDetail | null>(null);
   const [editingLoading, setEditingLoading] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deletingTarget, setDeletingTarget] = useState<OrderListRow | null>(null);
 
   const fetchOrders = useCallback(async () => {
     setLoading(true);
@@ -63,6 +74,20 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
   useEffect(() => {
     fetchOrders();
   }, [fetchOrders]);
+
+  const confirmDelete = async () => {
+    if (!deletingTarget) return;
+    setDeletingId(deletingTarget.id);
+    try {
+      await ordersApi.delete(deletingTarget.id);
+      setDeletingTarget(null);
+      await fetchOrders();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeletingId(null);
+    }
+  };
 
   const toggleExpand = async (row: OrderListRow) => {
     if (expandedId === row.id) {
@@ -179,7 +204,7 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
                 <th className="px-3 py-3 font-medium">Items / Delivery</th>
                 <th className="px-3 py-3 font-medium text-right">Total</th>
                 <th className="px-3 py-3 font-medium">Note</th>
-                <th className="w-12 px-2 py-3 font-medium"></th>
+                <th className="w-20 px-2 py-3 font-medium"></th>
                 <th className="w-32 px-3 py-3 font-medium text-right"></th>
               </tr>
             </thead>
@@ -192,9 +217,11 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
                   detail={details[o.id]}
                   printing={printingId === o.id}
                   editingLoading={editingLoading === o.id}
+                  deleting={deletingId === o.id}
                   onToggle={() => toggleExpand(o)}
                   onPrint={() => handlePrint(o)}
                   onEdit={() => handleEdit(o)}
+                  onDelete={() => setDeletingTarget(o)}
                 />
               ))}
             </tbody>
@@ -208,6 +235,36 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
           onSaved={afterEditSaved}
         />
       )}
+      {deletingTarget && (
+        <Dialog open onOpenChange={(open) => !open && !deletingId && setDeletingTarget(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Remove this order?</DialogTitle>
+              <DialogDescription>
+                Order {deletingTarget.orderNumber} ({deletingTarget.customerName}) will be hidden
+                from the list and locked so the next Re-sync won't bring it back. You can still
+                see it under <em>Show removed</em>.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setDeletingTarget(null)}
+                disabled={!!deletingId}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={confirmDelete}
+                disabled={!!deletingId}
+              >
+                {deletingId ? 'Removing…' : 'Remove'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }
@@ -218,9 +275,11 @@ interface OrderRowProps {
   detail: OrderDetail | undefined;
   printing: boolean;
   editingLoading: boolean;
+  deleting: boolean;
   onToggle: () => void;
   onPrint: () => void;
   onEdit: () => void;
+  onDelete: () => void;
 }
 
 function OrderRow({
@@ -229,9 +288,11 @@ function OrderRow({
   detail,
   printing,
   editingLoading,
+  deleting,
   onToggle,
   onPrint,
   onEdit,
+  onDelete,
 }: OrderRowProps) {
   const stopAndPrint = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -287,17 +348,28 @@ function OrderRow({
           ฿{row.totalAmount}
         </td>
         <td className="px-3 py-3 text-sm text-muted-foreground">{row.notes ?? ''}</td>
-        <td className="w-12 px-2 py-3 text-center">
+        <td className="w-20 px-2 py-3 text-center">
           {!removed && (
-            <Button
-              variant="ghost"
-              size="iconSm"
-              aria-label="Edit order"
-              onClick={stopAndEdit}
-              disabled={editingLoading}
-            >
-              <PencilLine className="h-4 w-4" />
-            </Button>
+            <div className="flex items-center justify-center gap-1">
+              <Button
+                variant="ghost"
+                size="iconSm"
+                aria-label="Edit order"
+                onClick={stopAndEdit}
+                disabled={editingLoading}
+              >
+                <PencilLine className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="iconSm"
+                aria-label="Delete order"
+                onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                disabled={deleting}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
           )}
         </td>
         <td className="w-32 px-3 py-3 text-right">

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -53,6 +53,40 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
   const [editingLoading, setEditingLoading] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deletingTarget, setDeletingTarget] = useState<OrderListRow | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [merging, setMerging] = useState(false);
+  const [mergeConfirm, setMergeConfirm] = useState<OrderListRow[] | null>(null);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const openMergeConfirm = () => {
+    const selected = orders.filter((o) => selectedIds.has(o.id));
+    if (selected.length < 2) return;
+    setMergeConfirm(selected);
+  };
+
+  const confirmMerge = async () => {
+    if (!mergeConfirm) return;
+    setMerging(true);
+    try {
+      await ordersApi.merge(mergeConfirm.map((o) => o.id));
+      setMergeConfirm(null);
+      setSelectedIds(new Set());
+      setDetails({});
+      await fetchOrders();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMerging(false);
+    }
+  };
 
   const fetchOrders = useCallback(async () => {
     setLoading(true);
@@ -64,6 +98,12 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
         limit: 500,
       });
       setOrders(rows);
+      setSelectedIds((prev) => {
+        const validIds = new Set(rows.map((r) => r.id));
+        const next = new Set<string>();
+        prev.forEach((id) => { if (validIds.has(id)) next.add(id); });
+        return next;
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -171,6 +211,11 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
             </SelectContent>
           </Select>
         </div>
+        {selectedIds.size >= 2 && (
+          <Button onClick={openMergeConfirm} disabled={merging}>
+            Merge {selectedIds.size} orders
+          </Button>
+        )}
         <Button variant="outline" onClick={fetchOrders}>
           <RefreshCw className="h-4 w-4" />
           Refresh
@@ -198,6 +243,7 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
             <thead className="sticky top-0 bg-card border-b border-border z-10">
               <tr className="text-muted-foreground text-xs uppercase tracking-wide text-left">
                 <th className="w-10 px-2 py-3"></th>
+                <th className="w-10 px-2 py-3"></th>
                 <th className="px-3 py-3 font-medium">Order #</th>
                 <th className="px-3 py-3 font-medium">Customer</th>
                 <th className="px-3 py-3 font-medium">Channel</th>
@@ -218,10 +264,12 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
                   printing={printingId === o.id}
                   editingLoading={editingLoading === o.id}
                   deleting={deletingId === o.id}
+                  selected={selectedIds.has(o.id)}
                   onToggle={() => toggleExpand(o)}
                   onPrint={() => handlePrint(o)}
                   onEdit={() => handleEdit(o)}
                   onDelete={() => setDeletingTarget(o)}
+                  onSelect={() => toggleSelect(o.id)}
                 />
               ))}
             </tbody>
@@ -265,6 +313,55 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
           </DialogContent>
         </Dialog>
       )}
+      {mergeConfirm && (
+        <Dialog open onOpenChange={(open) => !open && !merging && setMergeConfirm(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Merge {mergeConfirm.length} orders?</DialogTitle>
+              <DialogDescription>
+                {(() => {
+                  const sorted = [...mergeConfirm].sort(
+                    (a, b) => (a.sourceRow ?? 0) - (b.sourceRow ?? 0)
+                  );
+                  const master = sorted[0];
+                  const donors = sorted.slice(1);
+                  const customers = new Set(mergeConfirm.map((o) => o.customerName));
+                  const sameCustomer = customers.size === 1;
+                  if (sameCustomer) {
+                    return (
+                      <>
+                        All items will be combined under <strong>{master.orderNumber}</strong>{' '}
+                        ({master.customerName}). They'll receive one receipt with all items and
+                        one QR code.
+                      </>
+                    );
+                  }
+                  return (
+                    <>
+                      {donors.map((d) => d.customerName).join(', ')}'s order
+                      {donors.length > 1 ? 's' : ''} will be merged into{' '}
+                      <strong>{master.customerName}</strong>'s order ({master.orderNumber}).
+                      Only <strong>{master.customerName}</strong> will receive a receipt.
+                    </>
+                  );
+                })()}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setMergeConfirm(null)}
+                disabled={merging}
+              >
+                Cancel
+              </Button>
+              <Button onClick={confirmMerge} disabled={merging}>
+                {merging ? 'Merging…' : 'Merge'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }
@@ -276,10 +373,12 @@ interface OrderRowProps {
   printing: boolean;
   editingLoading: boolean;
   deleting: boolean;
+  selected: boolean;
   onToggle: () => void;
   onPrint: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onSelect: () => void;
 }
 
 function OrderRow({
@@ -289,10 +388,12 @@ function OrderRow({
   printing,
   editingLoading,
   deleting,
+  selected,
   onToggle,
   onPrint,
   onEdit,
   onDelete,
+  onSelect,
 }: OrderRowProps) {
   const stopAndPrint = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -314,6 +415,18 @@ function OrderRow({
           isExpanded && !removed && 'bg-accent/30',
         )}
       >
+        <td
+          className="w-10 px-2 py-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {!removed && (
+            <Checkbox
+              checked={selected}
+              onCheckedChange={() => onSelect()}
+              aria-label={`Select order ${row.orderNumber}`}
+            />
+          )}
+        </td>
         <td className="w-10 px-2 py-3 text-muted-foreground">
           {!removed &&
             (isExpanded ? (
@@ -329,6 +442,16 @@ function OrderRow({
               <Badge variant="warning" className="gap-1 font-normal" title="Locked from sync">
                 <Lock className="h-3 w-3" />
                 locked
+              </Badge>
+            )}
+            {row.mergedFromCount > 0 && (
+              <Badge variant="muted" className="gap-1 font-normal" title="This order has merged-in rows">
+                merged ×{row.mergedFromCount + 1}
+              </Badge>
+            )}
+            {row.mergedIntoId && (
+              <Badge variant="muted" className="font-normal" title="Merged into another order">
+                merged into
               </Badge>
             )}
           </div>
@@ -396,7 +519,7 @@ function OrderRow({
       {isExpanded && !removed && (
         <tr className="bg-accent/20">
           <td></td>
-          <td colSpan={8} className="px-3 py-4">
+          <td colSpan={9} className="px-3 py-4">
             {detail ? (
               <DetailPanel detail={detail} />
             ) : (

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -451,7 +451,7 @@ function OrderRow({
             )}
             {row.mergedIntoId && (
               <Badge variant="muted" className="font-normal" title="Merged into another order">
-                merged into
+                merged into {row.mergedIntoOrderNumber ?? '…'}
               </Badge>
             )}
           </div>


### PR DESCRIPTION
## Summary

Adds two new tools to the Orders page so the cashier can clean up after the Google Sheet sync:

- **Delete row** — trash icon on each order with a confirm dialog. Soft-deletes the order and locks it so the next Re-sync doesn't bring it back.
- **Merge orders** — multi-select 2+ rows for the same customer (e.g. the wife's habit of splitting K.Ing into two rows so the kitchen prepares each cake separately) and combine them into one receipt. Sheet edits keep flowing into the merged order via a new per-item `source_row` tag — no need to redo the merge each time a quantity changes upstream.

Also fixes the macOS "damaged and can't be opened" Gatekeeper error by ad-hoc signing the .app in CI.

## Design docs

- Spec: [`docs/superpowers/specs/2026-05-23-merge-orders-design.md`](../blob/claude/sweet-goodall-0be26b/docs/superpowers/specs/2026-05-23-merge-orders-design.md)
- Brainstorm: [`docs/brainstorms/2026-05-23-duplicate-rows.html`](../blob/claude/sweet-goodall-0be26b/docs/brainstorms/2026-05-23-duplicate-rows.html)
- Plan: [`docs/superpowers/plans/2026-05-23-merge-orders.md`](../blob/claude/sweet-goodall-0be26b/docs/superpowers/plans/2026-05-23-merge-orders.md)

## What changed

**Schema (migration `0003_merge_orders.sql`)**
- `order.merged_into_id` — points at the master when this order has been folded into another.
- `order_item.source_row` — which sheet row produced this item. Backfilled from the parent order.

**Backend (Rust)**
- `delete_order(pool, id)` — soft-delete + `sync_locked = 1`, all in one transaction.
- `merge_orders(pool, ids[])` — master = lowest `source_row`; donor items re-parent onto master tagged with the donor's row; discount + delivery_fee summed; donor soft-deleted with `merged_into_id`. Constraints: same `source_tab` only, no locked rows, no already-merged, no soft-deleted.
- `upsert_from_source` now scopes its item refresh by `source_row` so a master holding items from multiple sheet rows isn't wiped when one row syncs.
- Sync engine: a donor-row update routes through to the master's items (tagged by source_row); a vanished donor row strips its items from the master and recomputes the total. The master's `sync_locked` is respected by the pull-through, so an in-app edit to a merged order isn't overwritten by future syncs.

**Frontend (React + TypeScript)**
- Trash icon + confirm dialog on each row.
- Multi-select checkbox column; `Merge N orders` button appears when ≥2 rows are selected.
- Confirm dialog with two distinct wordings: same-customer vs cross-customer (lenient — allowed with explicit consent).
- `merged ×N` badge on the master row; `merged into <order_number>` badge on donor rows (visible under Show removed).

**CI**
- `APPLE_SIGNING_IDENTITY: '-'` added to the macOS bundler step. Gatekeeper now opens the app after a one-time right-click → Open. Windows build unaffected.

## What's deferred (documented in the spec)

- **Un-merge button.** The merge confirm dialog is the safety net; we'll add un-merge if accidents are common in practice.
- **Group without merging** (Option C from the brainstorm) and **Print together without DB merge** (Option A).
- **Detail panel: items grouped by `source_row`.** The `merged ×N` badge already signals merge; full grouping is nice-to-have polish.

## Workflow note for the reviewer / cashier

The intended order of operations is **merge first, then edit if needed**. Editing an order via `EditOrderDialog` sets `sync_locked = 1`, and the merge constraint rejects locked rows. The error message tells the user to unlock — there's currently no "unlock" action in the UI, so flipping that flag means either un-locking via SQL or replacing the row. If this trips people up in practice, a follow-up PR can add an unlock button next to the existing edit/delete actions.

## Test plan

- [x] `cd src-tauri && cargo test --lib` — 46 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 17 passed
- [x] `npm run build` — clean production bundle
- [x] Manual smoke (real Google Sheet): added a "Test Mee" customer with 2 rows, merged successfully into one receipt. K.Ing merge required unlocking one row (artifact of pre-feature data); future cases shouldn't hit this if the merge-first workflow is followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)