### PR TITLE
fix(sync): surface menu price drift instead of applying stale alias price

### DIFF
--- a/src-tauri/src/db/products.rs
+++ b/src-tauri/src/db/products.rs
@@ -70,6 +70,13 @@ pub async fn find_by_alias(pool: &SqlitePool, alias: &str) -> Result<Option<Prod
     .bind(alias).fetch_optional(pool).await
 }
 
+pub async fn update_price(pool: &SqlitePool, id: &str, selling_price: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE product SET selling_price = ?, updated_at = ? WHERE id = ?")
+        .bind(selling_price).bind(now_iso()).bind(id)
+        .execute(pool).await?;
+    Ok(())
+}
+
 pub async fn upsert_alias(pool: &SqlitePool, alias: &str, product_id: &str) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"INSERT INTO product_alias (id, alias, product_id, created_at)

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -66,13 +66,35 @@ pub async fn preview_sync(
     let price_by_alias = positional_price_by_alias(&parsed.order_columns, &parsed.menu);
 
     let mut unknown_menus: Vec<UnknownMenu> = Vec::new();
+    let mut drifted_menus: Vec<DriftedMenu> = Vec::new();
     let mut seen_menu_alias = std::collections::HashSet::new();
     for alias in &parsed.order_columns {
         if !seen_menu_alias.insert(alias.clone()) { continue; }
         if ignored_menu.contains(alias) { continue; }
-        if products::find_by_alias(pool, alias).await?.is_none() {
-            let price = price_by_alias.get(alias).copied().unwrap_or(0);
-            unknown_menus.push(UnknownMenu { alias: alias.clone(), suggested_price: price });
+        match products::find_by_alias(pool, alias).await? {
+            None => {
+                let price = price_by_alias.get(alias).copied().unwrap_or(0);
+                unknown_menus.push(UnknownMenu { alias: alias.clone(), suggested_price: price });
+            }
+            Some(product) => {
+                // Known alias: the price on the sheet this week is the only
+                // signal that the wife has repointed this header at a repriced
+                // or different cake. If it disagrees with the bound product's
+                // price, surface it instead of silently applying the stale one.
+                // A ฿0 (missing) positional price carries no signal — skip it.
+                if let Some(&sheet_price) = price_by_alias.get(alias) {
+                    if sheet_price > 0 && sheet_price != product.selling_price {
+                        drifted_menus.push(DriftedMenu {
+                            alias: alias.clone(),
+                            product_id: product.id.clone(),
+                            product_name_th: product.name_th.clone(),
+                            product_name_en: product.name_en.clone(),
+                            current_price: product.selling_price,
+                            sheet_price,
+                        });
+                    }
+                }
+            }
         }
     }
 
@@ -108,6 +130,7 @@ pub async fn preview_sync(
         tab: tab.to_string(),
         week_start_date: week_start,
         unknown_menus,
+        drifted_menus,
         unknown_customers,
         parsed_orders: parsed.orders,
         will_insert, will_update, will_soft_delete,
@@ -132,9 +155,19 @@ pub async fn apply_sync(
     // we want one product, not two — otherwise future catalog edits diverge.
     let mut menu_alias_to_product: HashMap<String, String> = HashMap::new();
     let mut created_menu_by_payload: HashMap<(String, Option<String>, i64), String> = HashMap::new();
+    // Aliases the cashier explicitly resolved in this request. A drifted alias
+    // already resolves via find_by_alias, so the "already in DB" backfill below
+    // would satisfy a contains_key gate without any human decision — we gate on
+    // this set instead to force an explicit choice for every drift.
+    let explicitly_mapped: std::collections::HashSet<String> =
+        mappings.menu.iter().map(|(a, _)| a.clone()).collect();
     for (alias, choice) in mappings.menu {
         let pid = match choice {
             MenuMappingChoice::Existing { product_id } => product_id,
+            MenuMappingChoice::UpdatePrice { product_id, selling_price } => {
+                products::update_price(pool, &product_id, selling_price).await?;
+                product_id
+            }
             MenuMappingChoice::Create { name_th, name_en, selling_price } => {
                 let key = (name_th.clone(), name_en.clone(), selling_price);
                 if let Some(existing) = created_menu_by_payload.get(&key) {
@@ -186,6 +219,14 @@ pub async fn apply_sync(
     for um in &preview.unknown_menus {
         if !menu_alias_to_product.contains_key(&um.alias) {
             return Err(anyhow!("Menu alias unresolved: {}", um.alias));
+        }
+    }
+    for dm in &preview.drifted_menus {
+        if !explicitly_mapped.contains(&dm.alias) {
+            return Err(anyhow!(
+                "Menu price drift unresolved: {} (sheet ฿{} vs ฿{})",
+                dm.alias, dm.sheet_price, dm.current_price
+            ));
         }
     }
     for uc in &preview.unknown_customers {
@@ -779,5 +820,76 @@ mod tests {
         assert_eq!(alive.len(), 1);
         let printed = crate::db::orders::get_with_items(&pool, &cust1_id).await.unwrap().unwrap().0;
         assert!(printed.printed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn reused_header_price_drift_is_surfaced_and_blocks_until_resolved() {
+        // Regression for the silent overcharge: the wife reuses a short column
+        // header across weeks. When she repoints it at a repriced cake, the
+        // global exact alias used to apply the OLD price with no unknown
+        // surfaced. Now the price mismatch surfaces as a drift that blocks
+        // apply until the cashier resolves it.
+        let pool = init_memory_pool().await.unwrap();
+
+        // Week A: header "Taro" priced 129, mapped to a new product.
+        let week_a = make_vr(vec![
+            vec!["Menu", "", "Total", "Left", "Price"],
+            vec!["Taro", "", "10", "5", "129"],
+            vec![""],
+            vec!["ช่องทาง", "ลูกค้า", "Taro", "สถานที่ส่ง", "Note"],
+            vec!["Page", "C1", "1", "Home", ""],
+        ]);
+        let fake_a = fake_with("Order_40", week_a);
+        let pa = preview_sync(&pool, &fake_a, "ss", "Order_40").await.unwrap();
+        assert_eq!(pa.unknown_menus.len(), 1);
+        assert!(pa.drifted_menus.is_empty(), "nothing bound yet → no drift");
+        apply_sync(&pool, &fake_a, "ss", "Order_40", SyncMappings {
+            menu: vec![("Taro".into(), MenuMappingChoice::Create {
+                name_th: "เค้กโคตรเผือกมะพร้าวอ่อน".into(), name_en: None, selling_price: 129 })],
+            customer: vec![("C1".into(), CustomerMappingChoice::Create { name: "C1".into() })],
+        }).await.unwrap();
+        let product_id = products::find_by_alias(&pool, "Taro").await.unwrap().unwrap().id;
+
+        // Week B (different tab): SAME header "Taro", but the menu changed — 115.
+        let week_b = make_vr(vec![
+            vec!["Menu", "", "Total", "Left", "Price"],
+            vec!["Taro", "", "10", "5", "115"],
+            vec![""],
+            vec!["ช่องทาง", "ลูกค้า", "Taro", "สถานที่ส่ง", "Note"],
+            vec!["Page", "C1", "2", "Home", ""],
+        ]);
+        let fake_b = fake_with("Order_41", week_b);
+        let pb = preview_sync(&pool, &fake_b, "ss", "Order_41").await.unwrap();
+
+        // The reused header resolves (not unknown) but the price mismatch drifts.
+        assert!(pb.unknown_menus.is_empty(), "known alias must not surface as unknown");
+        assert_eq!(pb.drifted_menus.len(), 1, "price mismatch must surface as drift");
+        let d = &pb.drifted_menus[0];
+        assert_eq!(d.alias, "Taro");
+        assert_eq!(d.current_price, 129);
+        assert_eq!(d.sheet_price, 115);
+        assert_eq!(d.product_id, product_id);
+
+        // Applying without resolving the drift is blocked.
+        let blocked = apply_sync(&pool, &fake_b, "ss", "Order_41",
+            SyncMappings { menu: vec![], customer: vec![] }).await;
+        assert!(blocked.is_err(), "unresolved drift must block apply");
+
+        // Resolve via UpdatePrice → product adopts 115 and the order is priced at 115.
+        apply_sync(&pool, &fake_b, "ss", "Order_41", SyncMappings {
+            menu: vec![("Taro".into(), MenuMappingChoice::UpdatePrice {
+                product_id: product_id.clone(), selling_price: 115 })],
+            customer: vec![],
+        }).await.unwrap();
+
+        let updated = products::get_by_id(&pool, &product_id).await.unwrap().unwrap();
+        assert_eq!(updated.selling_price, 115, "product price updated to sheet price");
+        let rows = crate::db::orders::list_by_tab(&pool, Some("Order_41"), false, 100).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].total_amount, 230, "2 × ฿115");
+
+        // A second preview now sees no drift (prices agree).
+        let pb2 = preview_sync(&pool, &fake_b, "ss", "Order_41").await.unwrap();
+        assert!(pb2.drifted_menus.is_empty(), "drift clears once prices agree");
     }
 }

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -153,6 +153,12 @@ pub async fn apply_sync(
     // two different unknown aliases (top-menu list + a shortened order column
     // header). If the user fills both rows with identical "Create new" details
     // we want one product, not two — otherwise future catalog edits diverge.
+    //
+    // NB: these catalog mutations (update_price / create / upsert_alias) commit
+    // immediately, *before* the order transaction below. If the order tx later
+    // fails, the catalog edits stay applied — and a retry preview then sees the
+    // price already matching, so the drift silently self-resolves. Benign because
+    // every catalog op here is idempotent, but non-obvious.
     let mut menu_alias_to_product: HashMap<String, String> = HashMap::new();
     let mut created_menu_by_payload: HashMap<(String, Option<String>, i64), String> = HashMap::new();
     // Aliases the cashier explicitly resolved in this request. A drifted alias

--- a/src-tauri/src/sync/types.rs
+++ b/src-tauri/src/sync/types.rs
@@ -14,12 +14,29 @@ pub struct UnknownCustomer {
     pub alias: String,
 }
 
+/// A menu column header that already resolves to a product, but whose price on
+/// the sheet this week disagrees with the bound product's price. The wife reuses
+/// short headers across weeks; when she repoints one at a repriced or different
+/// cake, the stale alias would otherwise apply the old price silently. We surface
+/// the conflict so the cashier must decide rather than letting it slip through.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DriftedMenu {
+    pub alias: String,
+    pub product_id: String,
+    pub product_name_th: String,
+    pub product_name_en: Option<String>,
+    pub current_price: i64,
+    pub sheet_price: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncPreview {
     pub tab: String,
     pub week_start_date: String,
     pub unknown_menus: Vec<UnknownMenu>,
+    pub drifted_menus: Vec<DriftedMenu>,
     pub unknown_customers: Vec<UnknownCustomer>,
     pub parsed_orders: Vec<ParsedOrder>,
     pub will_insert: i64,
@@ -39,6 +56,10 @@ pub enum MenuMappingChoice {
     Existing { product_id: String },
     #[serde(rename_all = "camelCase")]
     Create { name_th: String, name_en: Option<String>, selling_price: i64 },
+    // Resolution for a drifted alias: keep the same product but adopt the
+    // sheet's new price, updating the product so future weeks stay aligned.
+    #[serde(rename_all = "camelCase")]
+    UpdatePrice { product_id: String, selling_price: i64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/sync/types.rs
+++ b/src-tauri/src/sync/types.rs
@@ -121,6 +121,27 @@ mod tests {
     }
 
     #[test]
+    fn menu_mapping_update_price_uses_camel_case() {
+        let json = serde_json::json!({
+            "updatePrice": { "productId": "abc", "sellingPrice": 115 }
+        });
+        let decoded: MenuMappingChoice = serde_json::from_value(json.clone()).unwrap();
+        match decoded {
+            MenuMappingChoice::UpdatePrice { product_id, selling_price } => {
+                assert_eq!(product_id, "abc");
+                assert_eq!(selling_price, 115);
+            }
+            other => panic!("expected UpdatePrice, got {:?}", other),
+        }
+        // Round-trip back to the same JSON shape the TS layer sends.
+        let encoded = serde_json::to_value(&MenuMappingChoice::UpdatePrice {
+            product_id: "abc".into(),
+            selling_price: 115,
+        }).unwrap();
+        assert_eq!(encoded, json);
+    }
+
+    #[test]
     fn menu_mapping_existing_uses_camel_case() {
         let json = serde_json::json!({ "existing": { "productId": "abc" } });
         let decoded: MenuMappingChoice = serde_json::from_value(json).unwrap();

--- a/src/components/MappingForm.tsx
+++ b/src/components/MappingForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { AlertTriangle, EyeOff, Undo2 } from 'lucide-react';
 import { catalog, sheets } from '../lib/tauri';
 import type {
@@ -8,6 +8,7 @@ import type {
   SyncMappings,
   SyncPreview,
 } from '../lib/types';
+import { cn } from '../lib/cn';
 import SearchPicker, { type SearchResult } from './SearchPicker';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -34,6 +35,43 @@ type CustomerRow = {
   draft: { name: string } | null;
 };
 
+type DriftRow = {
+  alias: string;
+  productId: string;
+  productNameTh: string;
+  productNameEn: string | null;
+  currentPrice: number;
+  sheetPrice: number;
+  action: 'keep' | 'update' | 'remap' | null;
+  remapSelected: SearchResult | null;
+  remapDraft: { nameTh: string; nameEn: string; sellingPrice: number } | null;
+};
+
+const driftResolved = (r: DriftRow): boolean =>
+  r.action === 'keep' ||
+  r.action === 'update' ||
+  (r.action === 'remap' && (r.remapSelected !== null || r.remapDraft !== null));
+
+const driftChoice = (r: DriftRow): MenuMappingChoice => {
+  if (r.action === 'update') {
+    return { updatePrice: { productId: r.productId, sellingPrice: r.sheetPrice } };
+  }
+  if (r.action === 'remap' && r.remapSelected) {
+    return { existing: { productId: r.remapSelected.id } };
+  }
+  if (r.action === 'remap' && r.remapDraft) {
+    return {
+      create: {
+        nameTh: r.remapDraft.nameTh,
+        nameEn: r.remapDraft.nameEn.trim() ? r.remapDraft.nameEn : null,
+        sellingPrice: r.remapDraft.sellingPrice,
+      },
+    };
+  }
+  // 'keep' — alias stays bound to the same product.
+  return { existing: { productId: r.productId } };
+};
+
 export default function MappingForm({ preview, onApply, onCancel, applying }: MappingFormProps) {
   const [menuRows, setMenuRows] = useState<MenuRow[]>(
     preview.unknownMenus.map((m) => ({
@@ -46,6 +84,19 @@ export default function MappingForm({ preview, onApply, onCancel, applying }: Ma
   const [customerRows, setCustomerRows] = useState<CustomerRow[]>(
     preview.unknownCustomers.map((c) => ({ alias: c.alias, selected: null, draft: null })),
   );
+  const [driftRows, setDriftRows] = useState<DriftRow[]>(
+    preview.driftedMenus.map((d) => ({
+      alias: d.alias,
+      productId: d.productId,
+      productNameTh: d.productNameTh,
+      productNameEn: d.productNameEn,
+      currentPrice: d.currentPrice,
+      sheetPrice: d.sheetPrice,
+      action: null,
+      remapSelected: null,
+      remapDraft: null,
+    })),
+  );
   // Order rows the cashier has chosen to skip this sync (e.g. duplicates or
   // garbage trailing rows). Persisted server-side; removed from the visible list.
   const [ignoredRows, setIgnoredRows] = useState<ParsedOrder[]>([]);
@@ -57,7 +108,8 @@ export default function MappingForm({ preview, onApply, onCancel, applying }: Ma
 
   const menuResolved = menuRows.every((r) => r.selected !== null || r.draft !== null);
   const customerResolved = customerRows.every((r) => r.selected !== null || r.draft !== null);
-  const canApply = menuResolved && customerResolved;
+  const driftsResolved = driftRows.every(driftResolved);
+  const canApply = menuResolved && customerResolved && driftsResolved;
 
   const ignoreMenu = async (alias: string) => {
     await sheets.ignoreMenu(preview.tab, alias);
@@ -89,18 +141,21 @@ export default function MappingForm({ preview, onApply, onCancel, applying }: Ma
   };
 
   const buildMappings = (): SyncMappings => ({
-    menu: menuRows.map((r): [string, MenuMappingChoice] => [
-      r.alias,
-      r.selected
-        ? { existing: { productId: r.selected.id } }
-        : {
-            create: {
-              nameTh: r.draft!.nameTh,
-              nameEn: r.draft!.nameEn.trim() ? r.draft!.nameEn : null,
-              sellingPrice: r.draft!.sellingPrice,
+    menu: [
+      ...menuRows.map((r): [string, MenuMappingChoice] => [
+        r.alias,
+        r.selected
+          ? { existing: { productId: r.selected.id } }
+          : {
+              create: {
+                nameTh: r.draft!.nameTh,
+                nameEn: r.draft!.nameEn.trim() ? r.draft!.nameEn : null,
+                sellingPrice: r.draft!.sellingPrice,
+              },
             },
-          },
-    ]),
+      ]),
+      ...driftRows.map((r): [string, MenuMappingChoice] => [r.alias, driftChoice(r)]),
+    ],
     customer: customerRows.map((r): [string, CustomerMappingChoice] => [
       r.alias,
       r.selected
@@ -123,6 +178,30 @@ export default function MappingForm({ preview, onApply, onCancel, applying }: Ma
             +{preview.willInsert} new · ~{preview.willUpdate} updated · −{preview.willSoftDelete} removed
           </span>
         </header>
+
+        {driftRows.length > 0 && (
+          <section className="space-y-3">
+            <div className="flex items-center gap-2 text-warning-foreground">
+              <AlertTriangle className="h-4 w-4" />
+              <h3 className="font-semibold">Price changed since last sync ({driftRows.length})</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              These names already map to a product, but this week's sheet price differs.
+              Confirm what each one should do before syncing.
+            </p>
+            <div className="space-y-3">
+              {driftRows.map((row, i) => (
+                <DriftRowEditor
+                  key={row.alias}
+                  row={row}
+                  onChange={(updated) =>
+                    setDriftRows((rows) => rows.map((r, idx) => (idx === i ? updated : r)))
+                  }
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {menuRows.length > 0 && (
           <section className="space-y-3">
@@ -324,6 +403,131 @@ function MenuRowEditor({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function DriftRowEditor({
+  row,
+  onChange,
+}: {
+  row: DriftRow;
+  onChange: (r: DriftRow) => void;
+}) {
+  const productLabel = row.productNameEn
+    ? `${row.productNameTh} · ${row.productNameEn}`
+    : row.productNameTh;
+  return (
+    <Card className="border-warning/40 bg-warning/5">
+      <CardContent className="pt-5 space-y-3">
+        <div>
+          <span className="font-medium">{row.alias}</span>
+          <span className="text-sm text-muted-foreground ml-2">→ {productLabel}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <DriftAction
+            active={row.action === 'keep'}
+            onClick={() => onChange({ ...row, action: 'keep', remapSelected: null, remapDraft: null })}
+          >
+            Keep ฿{row.currentPrice}
+          </DriftAction>
+          <DriftAction
+            active={row.action === 'update'}
+            onClick={() => onChange({ ...row, action: 'update', remapSelected: null, remapDraft: null })}
+          >
+            Update → ฿{row.sheetPrice}
+          </DriftAction>
+          <DriftAction
+            active={row.action === 'remap'}
+            onClick={() => onChange({ ...row, action: 'remap' })}
+          >
+            Remap / new product
+          </DriftAction>
+        </div>
+        {row.action === 'remap' && !row.remapDraft && (
+          <SearchPicker
+            placeholder="Map to a different product…"
+            search={async (q) => {
+              const items = await catalog.searchProducts(q);
+              return items.map((p) => ({
+                id: p.id,
+                primary: p.nameTh,
+                secondary: p.nameEn ?? null,
+              }));
+            }}
+            onPick={(r) => onChange({ ...row, remapSelected: r, remapDraft: null })}
+            onCreate={() =>
+              onChange({
+                ...row,
+                remapSelected: null,
+                remapDraft: { nameTh: row.alias, nameEn: '', sellingPrice: row.sheetPrice },
+              })
+            }
+            selected={row.remapSelected}
+          />
+        )}
+        {row.action === 'remap' && row.remapDraft && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-1.5">
+              <Label>Name (Thai)</Label>
+              <Input
+                value={row.remapDraft.nameTh}
+                onChange={(e) =>
+                  onChange({ ...row, remapDraft: { ...row.remapDraft!, nameTh: e.target.value } })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Name (English)</Label>
+              <Input
+                value={row.remapDraft.nameEn}
+                placeholder="optional"
+                onChange={(e) =>
+                  onChange({ ...row, remapDraft: { ...row.remapDraft!, nameEn: e.target.value } })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Price (฿)</Label>
+              <Input
+                type="number"
+                value={row.remapDraft.sellingPrice}
+                onChange={(e) =>
+                  onChange({
+                    ...row,
+                    remapDraft: {
+                      ...row.remapDraft!,
+                      sellingPrice: parseInt(e.target.value || '0', 10),
+                    },
+                  })
+                }
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DriftAction({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={active ? 'default' : 'secondary'}
+      className={cn(!active && 'text-muted-foreground')}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
   );
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,6 +117,15 @@ export interface UnknownCustomer {
   alias: string;
 }
 
+export interface DriftedMenu {
+  alias: string;
+  productId: string;
+  productNameTh: string;
+  productNameEn: string | null;
+  currentPrice: number;
+  sheetPrice: number;
+}
+
 export interface ParsedOrderItem {
   menuName: string;
   quantity: number;
@@ -135,6 +144,7 @@ export interface SyncPreview {
   tab: string;
   weekStartDate: string;
   unknownMenus: UnknownMenu[];
+  driftedMenus: DriftedMenu[];
   unknownCustomers: UnknownCustomer[];
   parsedOrders: ParsedOrder[];
   willInsert: number;
@@ -145,7 +155,8 @@ export interface SyncPreview {
 
 export type MenuMappingChoice =
   | { existing: { productId: string } }
-  | { create: { nameTh: string; nameEn: string | null; sellingPrice: number } };
+  | { create: { nameTh: string; nameEn: string | null; sellingPrice: number } }
+  | { updatePrice: { productId: string; sellingPrice: number } };
 
 export type CustomerMappingChoice =
   | { existing: { customerId: string } }


### PR DESCRIPTION
## Problem

Menu column headers map to products via a **global, permanent, exact** alias. The wife reuses short headers across weeks, so when she repoints one at a repriced or different cake, the stale alias silently applied the **old** price:

- `find_by_alias` resolves the known alias, so `preview_sync` never surfaced it as an unknown — no review prompt.
- `apply_sync` prices each item from the **resolved product**, not the sheet — so the sheet's correct price was discarded.

The disambiguating signal (sheet price ≠ product price) was already computed in `preview_sync` and then thrown away.

**Concrete impact:** `เค้กโคตรเผือก` was bound on 2026-05-16 to the ฿129 coconut cake; this week the menu rotated and it means a no-coconut **฿115** cake. 9 current-week orders were silently overcharged ฿14 on that line. (Affected order data was corrected directly in the local DB, separately from this code change.)

## Fix — price-drift guard

Design: **blocking**, **price-only signal** (chosen via grilling the mechanism).

- `preview_sync` compares each *known* alias's positional sheet price against its bound product and emits a `DriftedMenu` on mismatch (non-zero sheet price only).
- `apply_sync` **blocks** on any unresolved drift — gated on aliases the cashier *explicitly* resolved, not the auto-backfill (which would otherwise pass the gate with no human decision).
- New `MenuMappingChoice::UpdatePrice` + `products::update_price`.
- `MappingForm` shows a warning section per drift with three actions: **Keep ฿old** / **Update → ฿new** / **Remap / new product**.

## Scope — what this does NOT catch

This is a **price**-drift guard, not wrong-product detection. If a reused header is repointed at a **different cake that happens to share the old price**, then `sheet_price == product.selling_price`, **no drift fires** (engine.rs:86), and the order is silently attributed to the wrong product — **right total, wrong name on the receipt**. Price is the only signal we trust here; a same-price product swap is invisible to it.

The real fix for that class is **per-week alias scoping** (re-confirm mappings each week), which is a larger change and deliberately out of scope. The drift guard's job is narrower but real: catch the case where a header's *meaning* changed and its *price* moved with it — which is what actually happened.

## Tests

- New regression test `reused_header_price_drift_is_surfaced_and_blocks_until_resolved` reproduces the cross-week silent overcharge — verified **red** without the detection, **green** with it.
- Serde round-trip test `menu_mapping_update_price_uses_camel_case` locks the `UpdatePrice` JSON wire format (the variant is only ever built in Rust elsewhere, so a camelCase rename typo would otherwise break only at the live Tauri boundary).
- Full suite: 53 Rust + 21 frontend pass, `tsc` clean.

## Known follow-ups (not in this PR)

- **Duplicate products:** two identical `เค้กโคตรเผือกมะพร้าวอ่อน` rows exist (different short headers each spawned their own product) — worth a dedup pass. ⚠️ Older weeks (`16-17/05`, `23-24/05`) reference one of them as legitimately coconut — confirm with the user before any dedup.
- **Same-price product swap** stays silent (see Scope above) — would need per-week alias scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)