### PR TITLE
Ambient config, order-view module, and menu price-column fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,105 +4,79 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Point of Sale (POS) system built with Python that prints receipts to thermal printers. The application uses Eel framework to create a desktop app with a web-based UI for managing products, orders, and printing receipts with PromptPay QR codes.
+**Granny's POS** (`grannys-pos`) is a Tauri 2 desktop point-of-sale app. A small
+bakery's orders are entered into a weekly Google Sheet; this app syncs those
+orders into a local SQLite store and prints receipts (with PromptPay QR codes)
+to a network thermal printer. Thai-language receipts.
 
-## Development Setup
+- **Frontend**: React 18 + TypeScript + Vite, Tailwind + Radix/shadcn UI, Zustand for cart state.
+- **Backend**: Rust (`src-tauri/`) — SQLite via `sqlx`, Google Sheets HTTP client, ESC/POS printing.
 
-### Prerequisites
-- Python 3.8 (required for compatibility)
-- Virtual environment recommended
+## Commands
 
-### Installation Commands
 ```bash
-# Create virtual environment
-python -m venv venv
+npm run tauri dev        # run the full desktop app (Rust + webview) — use this, not `npm run dev`
+npm run dev              # vite-only frontend on :1420 (no Tauri APIs; invoke() calls fail)
+npm run build            # tsc typecheck + vite build (frontend only)
+npm run tauri build      # build distributable .dmg / .msi
 
-# Activate virtual environment (Windows)
-venv\Scripts\activate
+npm test                 # frontend unit tests (vitest run)
+npx vitest run src/lib/orderEdit.test.ts   # single file
+npx vitest run -t "merge"                  # by test name
+npm run test:e2e         # Playwright layout tests (spins up vite on :1420)
 
-# Activate virtual environment (Unix/Linux/macOS)
-source venv/bin/activate
-
-# Install dependencies
-pip install -r requirement.txt
+cd src-tauri && cargo test                 # all Rust tests
+cd src-tauri && cargo test preview_sync    # single Rust test by name
 ```
 
-### Running the Application
-```bash
-# Development mode
-python mini-pos.py
-
-# Create executable
-python -m eel mini-pos.py web --add-data "_internal/*;."
-```
+There is no separate lint script; `npm run build` runs `tsc` as the typecheck gate.
 
 ## Architecture
 
-### Core Components
+### IPC boundary (the spine)
+All frontend↔backend calls go through `src/lib/tauri.ts`, which wraps
+`@tauri-apps/api` `invoke()`. Every command it calls **must** be registered in
+the `invoke_handler!` macro in `src-tauri/src/lib.rs`. Adding a feature that
+crosses the boundary means touching three places: the Rust command in
+`src-tauri/src/commands/`, the registration in `lib.rs`, and the typed wrapper
+in `tauri.ts`.
 
-**Main Application (`mini-pos.py`)**
-- Eel-based desktop application with web UI
-- Exposes Python functions to JavaScript via `@eel.expose` decorator
-- Manages CSV data files for products and orders
-- Handles thermal printer communication via escpos library
-- Integrates with Google Sheets for data synchronization
+JS sends **camelCase** args; Rust structs use `#[serde(rename_all = "camelCase")]`
+so e.g. `printerIp` ↔ `printer_ip`. Keep both sides in sync or the call silently
+fails to deserialize.
 
-**Data Storage**
-- Products: CSV file with columns [id, name, price]
-- Orders: CSV file with columns [date, customer_name, items, quantities, prices]
-- Config: JSON file for printer settings, shop details, and QR code configuration
-- All data files stored in `~/.mini-pos/` directory (persistent storage)
+### Backend layers (`src-tauri/src/`)
+- `commands/` — thin Tauri command handlers (config, printer, sync, catalog, orders). Validation + orchestration only.
+- `db/` — `sqlx` data access. SQLite at `<app_data_dir>/pos.sqlite`, WAL mode, foreign keys on. Schema lives in `db/migrations/*.sql` (run automatically at startup via `sqlx::migrate!`). Tables: `order`, `order_item`, `product`, `customer`, `product_alias`, `customer_alias`, `sync_log`, `tab_week_mapping`, sync-ignore. **Schema changes = new numbered migration file**, never edit an applied one.
+- `sheets/` — Google Sheets: service-account JWT auth (`auth.rs`), HTTP client (`client.rs`), tab parsing (`parser.rs`), week-from-tab-name logic (`week.rs`).
+- `sync/engine.rs` — the most intricate module; read it before touching sync. See below.
+- `printer/` — ESC/POS over TCP (`network.rs`), receipt layout (`receipt.rs`), Thai text shaping (`thai.rs`), PromptPay QR (`promptpay.rs`).
+- `state.rs` — `AppState` holds the DB pool, the live `AppConfig` (loaded once at startup; commands read `state.config()` rather than taking config per-call — only the "test what I typed" commands `test_sheets_connection`/`test_printer` take explicit input), and a lazily-built, cached `SheetsClient` (dropped on `save_config`). `config.rs` — `AppConfig` (persisted as JSON); `load_or_init` is the single load path, `migrate_from_json` gives forward-compat on old config files.
 
-**Web UI (`web/` directory)**
-- Bootstrap-based responsive interface
-- Three main tabs: Receipt, Products, Configuration
-- JavaScript files handle UI interactions and communicate with Python backend
+### The sync engine (`sync/engine.rs`)
+Two-phase: `preview_sync` (read-only diff shown to the user) → `apply_sync`
+(writes). The hard part is **menu alias reconciliation**: a weekly tab has two
+surfaces holding menu names — a top summary table (column A, carries prices) and
+the order-table column headers (what each order row references, often a
+shortened/Thai form). They're maintained in the *same order*, so price is
+recovered **positionally** (column N ↔ summary row N). The engine surfaces
+*unknown* menus (no product alias), *drifted* prices (sheet price ≠ bound
+product's price — surfaced, never silently applied), and honors per-tab
+**ignore** lists for rows and menu names. Catalog mutations (new aliases/prices)
+commit before the order transaction.
 
-**Printer Integration**
-- Network thermal printer support via escpos library
-- Receipt printing with logo, items, discounts, delivery fees
-- PromptPay QR code generation for payments
-- Printer connectivity testing functionality
+### Frontend (`src/`)
+- `App.tsx` — four tabs (Orders, Sync, POS, Settings), each a page in `pages/`.
+- `stores/cart.ts` — Zustand cart (items, customer, discount, delivery fee, totals).
+- `lib/types.ts` — shared TS types mirroring the Rust serde structs (single source of truth for the IPC payload shapes).
+- `components/ui/` — shadcn/Radix primitives; `components/` — app components.
+- Order-edit and aggregation logic (`lib/orderEdit.ts`, `lib/aggregateOrderItems.ts`) is unit-tested in isolation — prefer adding logic there over inline in components.
 
-**PromptPay Integration (`_internal/promptpay.py`)**
-- Generates Thai PromptPay QR codes for phone numbers or ID cards
-- Includes CRC-16 checksum calculation for QR code validation
+### Tests
+- **vitest** (`src/**/*.test.{ts,tsx}`, jsdom) for unit/component logic.
+- **Playwright** (`e2e/`) exists *only* for CSS layout bugs jsdom can't catch (overflow/ellipsis). Don't put logic tests here.
+- **cargo test** for all backend logic; sync/db tests use an in-memory SQLite pool (`db::pool::init_memory_pool`).
 
-### Key Features
-- Product management (add, edit, delete)
-- Order processing with discounts and delivery fees
-- Thermal receipt printing with PromptPay QR codes
-- Google Sheets synchronization for data backup
-- Network printer connectivity testing
-- Configurable shop information and printer settings
-
-## Build and Deployment
-
-### GitHub Actions Workflow
-The project includes automated building for Windows and macOS:
-```bash
-# Manually trigger build workflow
-# Uses Python 3.8 on both Windows and macOS runners
-# Creates single executable files for distribution
-```
-
-### Manual Build
-```bash
-python -m eel mini-pos.py web --add-data "_internal:_internal" --add-data "static:static" --onefile
-```
-
-## File Structure Notes
-
-- `static/`: Default configuration and CSV files (copied to user directory on first run)
-- `_internal/`: PromptPay QR code generation and CRC utilities
-- `web/`: Complete web interface with Bootstrap styling
-- Build outputs to `dist/` directory
-
-## Development Notes
-
-- Application automatically hides console window on Windows
-- Uses persistent user directory (`~/.mini-pos/`) for data storage
-- Thai language support in thermal printer output
-- Supports both percentage and fixed amount discounts
-- Delivery fee handling in order calculations
-- Real-time printer connectivity checking via ping
+## Notes
+- Design specs and plans live in `docs/superpowers/`; architecture decisions in `docs/adr/`.
+- Requires the webview Tauri runtime for any `invoke()` to work — pure-vite `npm run dev` is only useful for static UI work.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,25 @@ This only happens the first time.
 ## Need help?
 
 Open an issue on the [GitHub repo](https://github.com/panuphanch/mini-pos/issues) or ask the person who set this up for you.
+
+---
+
+## Development
+
+Built with [Tauri 2](https://tauri.app/) (Rust backend) + React 18 / TypeScript / Vite (frontend), SQLite for local storage, and the Google Sheets API for syncing weekly orders.
+
+**Prerequisites:** Node.js, Rust toolchain ([rustup](https://rustup.rs/)), and the [Tauri system dependencies](https://tauri.app/start/prerequisites/) for your OS.
+
+```bash
+npm install
+npm run tauri dev        # run the desktop app with hot reload
+npm run tauri build      # build a distributable .dmg / .msi
+
+npm test                 # frontend unit tests (vitest)
+npm run test:e2e         # Playwright layout tests
+cd src-tauri && cargo test   # backend tests
+```
+
+`npm run dev` runs the frontend alone on port 1420, but Tauri APIs are unavailable there — use `npm run tauri dev` to exercise the real app.
+
+See [CLAUDE.md](CLAUDE.md) for the architecture overview.

--- a/docs/adr/0001-hand-written-ipc-types.md
+++ b/docs/adr/0001-hand-written-ipc-types.md
@@ -1,0 +1,19 @@
+# Hand-write IPC types; defer Rust→TS codegen
+
+The Tauri IPC payload shapes exist twice — Rust serde structs (`commands/*.rs`,
+`db/orders.rs`) and TypeScript interfaces (`src/lib/types.ts`), kept in sync by
+hand and exercised through the wrappers in `src/lib/tauri.ts`. We considered
+generating the TS side from Rust (`ts-rs` for types, or `tauri-specta` for types
++ command wrappers) and **decided to keep hand-writing them for now**.
+
+At current scale — one developer, ~17 commands, IPC surface centralized in two
+files reviewed together — drift is low-risk and self-correcting: a mismatch
+fails loudly the first time the affected screen is exercised. Codegen buys
+*compile-time* drift detection, which only pays off when many people touch the
+seam or it changes often. Neither holds today; the build-step and annotation
+cost isn't worth it yet.
+
+**Revisit when** the command surface roughly doubles **or** a second developer
+joins. The lazy first step at that point is `ts-rs` (types only) — it leaves the
+hand-written wrappers alone and just makes `types.ts` generated; reach for
+`tauri-specta` only if command-name/arg drift also starts biting.

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1,41 +1,15 @@
-use crate::config::{migrate_from_json, AppConfig};
+use crate::config::AppConfig;
+use crate::state::AppState;
 use std::fs;
-use tauri::Manager;
+use tauri::State;
 
 #[tauri::command]
-pub fn load_config(app_handle: tauri::AppHandle) -> Result<AppConfig, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to resolve app data dir: {}", e))?;
-
-    let config_path = app_data_dir.join("config.json");
-
-    if config_path.exists() {
-        let content = fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read config: {}", e))?;
-        let cfg = migrate_from_json(&content)
-            .map_err(|e| format!("Failed to parse config: {}", e))?;
-        // Persist normalized (drops old fields).
-        let json = serde_json::to_string_pretty(&cfg)
-            .map_err(|e| format!("Failed to serialize config: {}", e))?;
-        fs::write(&config_path, json)
-            .map_err(|e| format!("Failed to write config: {}", e))?;
-        Ok(cfg)
-    } else {
-        let default_config = AppConfig::default();
-        fs::create_dir_all(&app_data_dir)
-            .map_err(|e| format!("Failed to create config dir: {}", e))?;
-        let json = serde_json::to_string_pretty(&default_config)
-            .map_err(|e| format!("Failed to serialize config: {}", e))?;
-        fs::write(&config_path, json)
-            .map_err(|e| format!("Failed to write default config: {}", e))?;
-        Ok(default_config)
-    }
+pub async fn load_config(state: State<'_, AppState>) -> Result<AppConfig, String> {
+    Ok(state.config().await)
 }
 
 #[tauri::command]
-pub fn save_config(app_handle: tauri::AppHandle, config: AppConfig) -> Result<String, String> {
+pub async fn save_config(state: State<'_, AppState>, config: AppConfig) -> Result<String, String> {
     if config.printer_ip.is_empty() {
         return Err("Printer IP cannot be empty".to_string());
     }
@@ -44,17 +18,13 @@ pub fn save_config(app_handle: tauri::AppHandle, config: AppConfig) -> Result<St
     }
     // spreadsheet_id may be empty until the user fills it in Settings.
 
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to resolve app data dir: {}", e))?;
-    fs::create_dir_all(&app_data_dir)
+    fs::create_dir_all(&state.app_data_dir)
         .map_err(|e| format!("Failed to create config dir: {}", e))?;
-
-    let config_path = app_data_dir.join("config.json");
+    let config_path = state.app_data_dir.join("config.json");
     let json = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
     fs::write(&config_path, json).map_err(|e| format!("Failed to write config: {}", e))?;
 
+    state.set_config(config).await;
     Ok("Config saved successfully".to_string())
 }

--- a/src-tauri/src/commands/orders.rs
+++ b/src-tauri/src/commands/orders.rs
@@ -1,68 +1,9 @@
-use crate::config::AppConfig;
 use crate::db::{customers, orders, products};
 use crate::printer::network;
 use crate::printer::receipt::{build_receipt, PrinterConfig, ReceiptData, ReceiptItem};
 use crate::state::AppState;
 use serde::{Deserialize, Serialize};
 use tauri::State;
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderListRow {
-    pub id: String,
-    pub order_number: String,
-    pub customer_name: String,
-    pub channel: Option<String>,
-    pub delivery_location: Option<String>,
-    pub total_amount: i64,
-    pub source_tab: Option<String>,
-    pub source_row: Option<i64>,
-    pub printed_at: Option<String>,
-    pub print_count: i64,
-    pub deleted_at: Option<String>,
-    pub order_date: String,
-    pub notes: Option<String>,
-    pub items_summary: String,
-    pub sync_locked: bool,
-    pub merged_into_id: Option<String>,
-    pub merged_into_order_number: Option<String>,
-    pub merged_from_count: i64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderDetailItem {
-    pub product_id: String,
-    pub name_th: String,
-    pub quantity: i64,
-    pub unit_price: i64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderDetail {
-    pub id: String,
-    pub order_number: String,
-    pub customer_name: String,
-    pub channel: Option<String>,
-    pub delivery_location: Option<String>,
-    pub notes: Option<String>,
-    pub status: String,
-    pub total_amount: i64,
-    pub discount: i64,
-    pub delivery_fee: i64,
-    pub order_date: String,
-    pub source_tab: Option<String>,
-    pub source_row: Option<i64>,
-    pub printed_at: Option<String>,
-    pub print_count: i64,
-    pub deleted_at: Option<String>,
-    pub sync_locked: bool,
-    pub merged_into_id: Option<String>,
-    pub merged_into_order_number: Option<String>,
-    pub merged_from_count: i64,
-    pub items: Vec<OrderDetailItem>,
-}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -86,98 +27,18 @@ pub async fn list_orders(
     tab: Option<String>,
     include_deleted: Option<bool>,
     limit: Option<i64>,
-) -> Result<Vec<OrderListRow>, String> {
-    let rows = orders::list_by_tab(
+) -> Result<Vec<orders::OrderListRow>, String> {
+    orders::list_view(
         &state.db, tab.as_deref(), include_deleted.unwrap_or(false), limit.unwrap_or(200),
-    ).await.map_err(|e| e.to_string())?;
-
-    let mut out = Vec::with_capacity(rows.len());
-    for r in rows {
-        let cust = customers::get_by_id(&state.db, &r.customer_id).await
-            .map_err(|e| e.to_string())?
-            .map(|c| c.name).unwrap_or_else(|| "(unknown)".into());
-        // Collapse identical products (same product + unit price) into one
-        // entry with summed quantity. A merged order keeps one order_item row
-        // per source sheet row, so the same product can appear several times;
-        // the summary should read "Carrot Cake×4", not four "Carrot Cake×1".
-        let items = sqlx::query_as::<_, (String, i64)>(
-            r#"SELECT p.name_th, SUM(oi.quantity) AS qty FROM order_item oi
-               JOIN product p ON p.id = oi.product_id
-               WHERE oi.order_id = ?
-               GROUP BY oi.product_id, oi.unit_price
-               ORDER BY MIN(oi.id)"#,
-        ).bind(&r.id).fetch_all(&state.db).await.map_err(|e| e.to_string())?;
-        let items_summary = items.iter()
-            .map(|(n, q)| format!("{}×{}", n, q))
-            .collect::<Vec<_>>().join(" ");
-        let merged_from_count: (i64,) = sqlx::query_as(
-            r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
-        ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
-        let merged_into_order_number: Option<String> = if let Some(ref mid) = r.merged_into_id {
-            let row: Option<(String,)> = sqlx::query_as(
-                r#"SELECT order_number FROM "order" WHERE id = ?"#,
-            ).bind(mid).fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
-            row.map(|t| t.0)
-        } else { None };
-        out.push(OrderListRow {
-            id: r.id, order_number: r.order_number, customer_name: cust,
-            channel: r.channel, delivery_location: r.delivery_location,
-            total_amount: r.total_amount,
-            source_tab: r.source_tab, source_row: r.source_row,
-            printed_at: r.printed_at, print_count: r.print_count,
-            deleted_at: r.deleted_at, order_date: r.order_date,
-            notes: r.notes, items_summary,
-            sync_locked: r.sync_locked != 0,
-            merged_into_id: r.merged_into_id,
-            merged_into_order_number,
-            merged_from_count: merged_from_count.0,
-        });
-    }
-    Ok(out)
+    ).await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn get_order(
     state: State<'_, AppState>,
     id: String,
-) -> Result<Option<OrderDetail>, String> {
-    let Some((r, items)) = orders::get_with_items(&state.db, &id).await
-        .map_err(|e| e.to_string())? else { return Ok(None); };
-    let cust = customers::get_by_id(&state.db, &r.customer_id).await
-        .map_err(|e| e.to_string())?
-        .map(|c| c.name).unwrap_or_else(|| "(unknown)".into());
-    let mut detail_items = Vec::with_capacity(items.len());
-    for it in items {
-        let p = products::get_by_id(&state.db, &it.product_id).await
-            .map_err(|e| e.to_string())?;
-        detail_items.push(OrderDetailItem {
-            product_id: it.product_id.clone(),
-            name_th: p.map(|p| p.name_th).unwrap_or_else(|| "(deleted product)".into()),
-            quantity: it.quantity, unit_price: it.unit_price,
-        });
-    }
-    let merged_from_count: (i64,) = sqlx::query_as(
-        r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#,
-    ).bind(&r.id).fetch_one(&state.db).await.map_err(|e| e.to_string())?;
-    let merged_into_order_number: Option<String> = if let Some(ref mid) = r.merged_into_id {
-        let row: Option<(String,)> = sqlx::query_as(
-            r#"SELECT order_number FROM "order" WHERE id = ?"#,
-        ).bind(mid).fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
-        row.map(|t| t.0)
-    } else { None };
-    Ok(Some(OrderDetail {
-        id: r.id, order_number: r.order_number, customer_name: cust,
-        channel: r.channel, delivery_location: r.delivery_location,
-        notes: r.notes, status: r.status, total_amount: r.total_amount,
-        discount: r.discount, delivery_fee: r.delivery_fee,
-        order_date: r.order_date, source_tab: r.source_tab, source_row: r.source_row,
-        printed_at: r.printed_at, print_count: r.print_count,
-        deleted_at: r.deleted_at, sync_locked: r.sync_locked != 0,
-        merged_into_id: r.merged_into_id,
-        merged_into_order_number,
-        merged_from_count: merged_from_count.0,
-        items: detail_items,
-    }))
+) -> Result<Option<orders::OrderDetail>, String> {
+    orders::get_view(&state.db, &id).await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -198,9 +59,9 @@ pub async fn update_order(
 #[tauri::command]
 pub async fn print_order(
     state: State<'_, AppState>,
-    config: AppConfig,
     id: String,
 ) -> Result<String, String> {
+    let config = state.config().await;
     let Some((order, items)) = orders::get_with_items(&state.db, &id).await
         .map_err(|e| e.to_string())? else {
         return Err(format!("Order {} not found", id));
@@ -232,17 +93,7 @@ pub async fn print_order(
         discount: order.discount as f64,
         delivery_fee: order.delivery_fee as f64,
     };
-    let printer = PrinterConfig {
-        ip: config.printer_ip.clone(),
-        paper_width: config.paper_width,
-        shop_name: config.shop_name.clone(),
-        shop_phone: config.shop_phone.clone(),
-        shop_line: config.shop_line.clone(),
-        qr_text: "Scan to Pay".to_string(),
-        qr_code_type: config.promptpay_type.clone(),
-        qr_code_value: config.promptpay_value.clone(),
-        thank_you_message: config.thank_you_message.clone(),
-    };
+    let printer = PrinterConfig::from(&config);
     let bytes = build_receipt(&receipt, &printer)
         .map_err(|e| format!("Build receipt: {}", e))?;
     network::send_to_printer(&printer.ip, &bytes)

--- a/src-tauri/src/commands/printer.rs
+++ b/src-tauri/src/commands/printer.rs
@@ -1,9 +1,16 @@
 use crate::printer::network;
 use crate::printer::receipt::{PrinterConfig, ReceiptData};
+use crate::state::AppState;
+use tauri::State;
 
-/// Print a full receipt to the thermal printer.
+/// Print a full receipt to the thermal printer. Printer config comes from the
+/// saved app config; only the cart-specific receipt data is passed in.
 #[tauri::command]
-pub fn print_receipt(receipt: ReceiptData, config: PrinterConfig) -> Result<String, String> {
+pub async fn print_receipt(
+    state: State<'_, AppState>,
+    receipt: ReceiptData,
+) -> Result<String, String> {
+    let config = PrinterConfig::from(&state.config().await);
     let commands = crate::printer::receipt::build_receipt(&receipt, &config)
         .map_err(|e| format!("Failed to build receipt: {}", e))?;
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -30,9 +30,9 @@ pub async fn test_sheets_connection(
 #[tauri::command]
 pub async fn sync_week(
     state: State<'_, AppState>,
-    config: AppConfig,
     tab: String,
 ) -> Result<SyncPreview, String> {
+    let config = state.config().await;
     let client = state.ensure_sheets_client(&config).await
         .map_err(|e| format!("Auth error: {}", e))?;
     engine::preview_sync(&state.db, client.as_ref(), &config.spreadsheet_id, &tab).await
@@ -42,10 +42,10 @@ pub async fn sync_week(
 #[tauri::command]
 pub async fn apply_sync(
     state: State<'_, AppState>,
-    config: AppConfig,
     tab: String,
     mappings: SyncMappings,
 ) -> Result<SyncResult, String> {
+    let config = state.config().await;
     let client = state.ensure_sheets_client(&config).await
         .map_err(|e| format!("Auth error: {}", e))?;
     engine::apply_sync(&state.db, client.as_ref(), &config.spreadsheet_id, &tab, mappings).await

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -52,8 +54,44 @@ impl Default for AppConfig {
     }
 }
 
+/// Read config.json from `app_data_dir`, or seed it with defaults. This is the
+/// single load path: `AppState` calls it once at startup and holds the result
+/// as the in-process source of truth. On a present-but-corrupt file we fall back
+/// to defaults *without* overwriting, so the bad file stays recoverable.
+pub fn load_or_init(app_data_dir: &Path) -> AppConfig {
+    let config_path = app_data_dir.join("config.json");
+    if config_path.exists() {
+        match fs::read_to_string(&config_path) {
+            Ok(content) => match migrate_from_json(&content) {
+                Ok(cfg) => {
+                    // Persist normalized (drops old fields, fills new ones).
+                    if let Ok(json) = serde_json::to_string_pretty(&cfg) {
+                        let _ = fs::write(&config_path, json);
+                    }
+                    cfg
+                }
+                Err(e) => {
+                    eprintln!("config parse failed, using defaults (file preserved): {e}");
+                    AppConfig::default()
+                }
+            },
+            Err(e) => {
+                eprintln!("config read failed, using defaults: {e}");
+                AppConfig::default()
+            }
+        }
+    } else {
+        let cfg = AppConfig::default();
+        let _ = fs::create_dir_all(app_data_dir);
+        if let Ok(json) = serde_json::to_string_pretty(&cfg) {
+            let _ = fs::write(&config_path, json);
+        }
+        cfg
+    }
+}
+
 /// Migrate older config JSON (with apiUrl etc.) by dropping unknown fields
-/// and filling defaults for missing ones. Called from `load_config`.
+/// and filling defaults for missing ones. Called from `load_or_init`.
 pub fn migrate_from_json(raw: &str) -> Result<AppConfig, serde_json::Error> {
     let v: serde_json::Value = serde_json::from_str(raw)?;
     let obj = v.as_object();
@@ -136,5 +174,33 @@ mod tests {
         let raw = r#"{ "defaultTabStrategy": { "pinned": "Order_30" } }"#;
         let cfg = migrate_from_json(raw).unwrap();
         assert_eq!(cfg.default_tab_strategy, TabStrategy::Pinned("Order_30".to_string()));
+    }
+
+    #[test]
+    fn load_or_init_seeds_default_when_missing() {
+        let dir = std::env::temp_dir().join("grannys-pos-test-cfg-missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = load_or_init(&dir);
+        assert_eq!(cfg.shop_name, "Granny's Bakery");
+        assert!(dir.join("config.json").exists(), "should seed config.json");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_or_init_reads_and_normalizes_existing() {
+        let dir = std::env::temp_dir().join("grannys-pos-test-cfg-existing");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{ "printerIp": "10.0.0.9", "paperWidth": 58, "apiUrl": "x" }"#,
+        ).unwrap();
+        let cfg = load_or_init(&dir);
+        assert_eq!(cfg.printer_ip, "10.0.0.9");
+        assert_eq!(cfg.paper_width, 58);
+        let written = std::fs::read_to_string(dir.join("config.json")).unwrap();
+        assert!(!written.contains("apiUrl"), "dropped field should not survive normalize");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/db/orders.rs
+++ b/src-tauri/src/db/orders.rs
@@ -268,6 +268,212 @@ pub fn aggregate_items(items: &[OrderItemRow]) -> Vec<AggregatedItem> {
     out
 }
 
+// === Read views ===
+//
+// The enriched shapes the UI consumes: an order joined with its customer name,
+// item summary/lines, and resolved merge relationships. All order-read SQL lives
+// behind `list_view` / `get_view` so command handlers stay thin and the merge
+// resolution is written once.
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderListRow {
+    pub id: String,
+    pub order_number: String,
+    pub customer_name: String,
+    pub channel: Option<String>,
+    pub delivery_location: Option<String>,
+    pub total_amount: i64,
+    pub source_tab: Option<String>,
+    pub source_row: Option<i64>,
+    pub printed_at: Option<String>,
+    pub print_count: i64,
+    pub deleted_at: Option<String>,
+    pub order_date: String,
+    pub notes: Option<String>,
+    pub items_summary: String,
+    pub sync_locked: bool,
+    pub merged_into_id: Option<String>,
+    pub merged_into_order_number: Option<String>,
+    pub merged_from_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderDetailItem {
+    pub product_id: String,
+    pub name_th: String,
+    pub quantity: i64,
+    pub unit_price: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderDetail {
+    pub id: String,
+    pub order_number: String,
+    pub customer_name: String,
+    pub channel: Option<String>,
+    pub delivery_location: Option<String>,
+    pub notes: Option<String>,
+    pub status: String,
+    pub total_amount: i64,
+    pub discount: i64,
+    pub delivery_fee: i64,
+    pub order_date: String,
+    pub source_tab: Option<String>,
+    pub source_row: Option<i64>,
+    pub printed_at: Option<String>,
+    pub print_count: i64,
+    pub deleted_at: Option<String>,
+    pub sync_locked: bool,
+    pub merged_into_id: Option<String>,
+    pub merged_into_order_number: Option<String>,
+    pub merged_from_count: i64,
+    pub items: Vec<OrderDetailItem>,
+}
+
+/// Resolve an order's merge relationships: how many donor rows point at it, and
+/// (if it is itself a donor) the order number it was merged into. Used by both
+/// the list and detail views — written once so the two can't drift.
+async fn merge_info(
+    pool: &SqlitePool,
+    id: &str,
+    merged_into_id: Option<&str>,
+) -> Result<(i64, Option<String>), sqlx::Error> {
+    let merged_from_count: (i64,) =
+        sqlx::query_as(r#"SELECT COUNT(*) FROM "order" WHERE merged_into_id = ?"#)
+            .bind(id)
+            .fetch_one(pool)
+            .await?;
+    let merged_into_order_number = match merged_into_id {
+        Some(mid) => sqlx::query_as::<_, (String,)>(
+            r#"SELECT order_number FROM "order" WHERE id = ?"#,
+        )
+        .bind(mid)
+        .fetch_optional(pool)
+        .await?
+        .map(|t| t.0),
+        None => None,
+    };
+    Ok((merged_from_count.0, merged_into_order_number))
+}
+
+/// Per-order item summary like "Carrot Cake×4 Mango×2". Collapses identical
+/// `(product, unit_price)` rows the way [`aggregate_items`] does, but in SQL for
+/// the list view. A merged order keeps one `order_item` row per source sheet
+/// row, so the same product can appear several times.
+async fn items_summary(pool: &SqlitePool, order_id: &str) -> Result<String, sqlx::Error> {
+    let items = sqlx::query_as::<_, (String, i64)>(
+        r#"SELECT p.name_th, SUM(oi.quantity) AS qty FROM order_item oi
+           JOIN product p ON p.id = oi.product_id
+           WHERE oi.order_id = ?
+           GROUP BY oi.product_id, oi.unit_price
+           ORDER BY MIN(oi.id)"#,
+    )
+    .bind(order_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(items
+        .iter()
+        .map(|(n, q)| format!("{}×{}", n, q))
+        .collect::<Vec<_>>()
+        .join(" "))
+}
+
+/// List orders for the UI, enriched with customer name, item summary, and merge
+/// relationships.
+// ponytail: per-order enrichment queries (N+1) — fine at weekly-bakery scale
+// (limit 200, dozens of rows). Batch into IN-clause queries if it ever grows.
+pub async fn list_view(
+    pool: &SqlitePool,
+    tab: Option<&str>,
+    include_deleted: bool,
+    limit: i64,
+) -> Result<Vec<OrderListRow>, sqlx::Error> {
+    let rows = list_by_tab(pool, tab, include_deleted, limit).await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for r in rows {
+        let customer_name = crate::db::customers::get_by_id(pool, &r.customer_id)
+            .await?
+            .map(|c| c.name)
+            .unwrap_or_else(|| "(unknown)".into());
+        let items_summary = items_summary(pool, &r.id).await?;
+        let (merged_from_count, merged_into_order_number) =
+            merge_info(pool, &r.id, r.merged_into_id.as_deref()).await?;
+        out.push(OrderListRow {
+            id: r.id,
+            order_number: r.order_number,
+            customer_name,
+            channel: r.channel,
+            delivery_location: r.delivery_location,
+            total_amount: r.total_amount,
+            source_tab: r.source_tab,
+            source_row: r.source_row,
+            printed_at: r.printed_at,
+            print_count: r.print_count,
+            deleted_at: r.deleted_at,
+            order_date: r.order_date,
+            notes: r.notes,
+            items_summary,
+            sync_locked: r.sync_locked != 0,
+            merged_into_id: r.merged_into_id,
+            merged_into_order_number,
+            merged_from_count,
+        });
+    }
+    Ok(out)
+}
+
+/// Full order detail for the UI, with item lines (product names) and merge info.
+pub async fn get_view(pool: &SqlitePool, id: &str) -> Result<Option<OrderDetail>, sqlx::Error> {
+    let Some((r, items)) = get_with_items(pool, id).await? else {
+        return Ok(None);
+    };
+    let customer_name = crate::db::customers::get_by_id(pool, &r.customer_id)
+        .await?
+        .map(|c| c.name)
+        .unwrap_or_else(|| "(unknown)".into());
+    let mut detail_items = Vec::with_capacity(items.len());
+    for it in items {
+        let name_th = crate::db::products::get_by_id(pool, &it.product_id)
+            .await?
+            .map(|p| p.name_th)
+            .unwrap_or_else(|| "(deleted product)".into());
+        detail_items.push(OrderDetailItem {
+            product_id: it.product_id,
+            name_th,
+            quantity: it.quantity,
+            unit_price: it.unit_price,
+        });
+    }
+    let (merged_from_count, merged_into_order_number) =
+        merge_info(pool, &r.id, r.merged_into_id.as_deref()).await?;
+    Ok(Some(OrderDetail {
+        id: r.id,
+        order_number: r.order_number,
+        customer_name,
+        channel: r.channel,
+        delivery_location: r.delivery_location,
+        notes: r.notes,
+        status: r.status,
+        total_amount: r.total_amount,
+        discount: r.discount,
+        delivery_fee: r.delivery_fee,
+        order_date: r.order_date,
+        source_tab: r.source_tab,
+        source_row: r.source_row,
+        printed_at: r.printed_at,
+        print_count: r.print_count,
+        deleted_at: r.deleted_at,
+        sync_locked: r.sync_locked != 0,
+        merged_into_id: r.merged_into_id,
+        merged_into_order_number,
+        merged_from_count,
+        items: detail_items,
+    }))
+}
+
 /// Apply a manual edit to an order. Replaces the line items, recomputes the
 /// total as `subtotal - discount + delivery_fee`, and flips `sync_locked = 1`
 /// so future syncs from the sheet leave this row alone.
@@ -1163,5 +1369,48 @@ mod tests {
         let n = soft_delete_missing_rows(&mut tx, "Order_30", &[4]).await.unwrap();
         tx.commit().await.unwrap();
         assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn views_enrich_with_customer_summary_and_merge_info() {
+        let pool = init_memory_pool().await.unwrap();
+        let (p, c) = seed_pc(&pool).await;
+        let mut tx = pool.begin().await.unwrap();
+        // Master with two same-product rows; after a donor merges in (its one
+        // row moves onto the master) the summary must collapse all three into
+        // one "name×3" entry.
+        let a = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 170, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 4,
+            items: vec![
+                UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 },
+                UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 },
+            ],
+        }).await.unwrap();
+        let b = upsert_from_source(&mut tx, UpsertOrderInput {
+            customer_id: &c.id, channel: None, delivery_location: None, notes: None,
+            total_amount: 85, order_date: "2026-05-11",
+            source_tab: "Order_30", source_row: 5,
+            items: vec![UpsertOrderItemInput { product_id: &p.id, quantity: 1, unit_price: 85 }],
+        }).await.unwrap();
+        tx.commit().await.unwrap();
+        merge_orders(&pool, &[a.order_id.clone(), b.order_id.clone()]).await.unwrap();
+
+        // Default list shows the master only, enriched.
+        let list = list_view(&pool, Some("Order_30"), false, 100).await.unwrap();
+        assert_eq!(list.len(), 1);
+        let master = &list[0];
+        assert_eq!(master.id, a.order_id);
+        assert_eq!(master.customer_name, "K.Parin");
+        assert_eq!(master.items_summary, "เค้กช็อคฟัดจ์×3");
+        assert_eq!(master.merged_from_count, 1, "one donor merged into the master");
+        assert!(master.merged_into_order_number.is_none());
+
+        // The donor, fetched directly, points back at the master's order number;
+        // its items have moved onto the master, so it carries none.
+        let donor = get_view(&pool, &b.order_id).await.unwrap().unwrap();
+        assert_eq!(donor.merged_into_order_number.as_deref(), Some(master.order_number.as_str()));
+        assert!(donor.items.is_empty());
     }
 }

--- a/src-tauri/src/printer/receipt.rs
+++ b/src-tauri/src/printer/receipt.rs
@@ -27,6 +27,24 @@ pub struct PrinterConfig {
     pub thank_you_message: String,
 }
 
+/// Build the printer config from the app config. Both print paths (POS receipt
+/// and saved-order receipt) go through here, so the QR caption lives in one place.
+impl From<&crate::config::AppConfig> for PrinterConfig {
+    fn from(c: &crate::config::AppConfig) -> Self {
+        PrinterConfig {
+            ip: c.printer_ip.clone(),
+            paper_width: c.paper_width,
+            shop_name: c.shop_name.clone(),
+            shop_phone: c.shop_phone.clone(),
+            shop_line: c.shop_line.clone(),
+            qr_text: "Scan to Pay".to_string(),
+            qr_code_type: c.promptpay_type.clone(),
+            qr_code_value: c.promptpay_value.clone(),
+            thank_you_message: c.thank_you_message.clone(),
+        }
+    }
+}
+
 /// A single item on the receipt.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/sheets/parser.rs
+++ b/src-tauri/src/sheets/parser.rs
@@ -60,6 +60,15 @@ fn cell<'a>(row: &'a [String], idx: usize) -> &'a str {
 pub fn parse_tab(vr: &ValueRange) -> Result<ParsedTab, ParseError> {
     let rows = &vr.values;
 
+    // Resolve the price column from the menu header row. Older tabs put Price at
+    // col E (idx 4); newer tabs (e.g. Order_35) widen the table with computed
+    // amount columns, pushing Price right (col F). Locate it by the "Price"
+    // header and fall back to idx 4 for old tabs.
+    let price_col = rows.iter()
+        .find(|r| cell(r, 0) == "Menu")
+        .and_then(|r| r.iter().position(|c| c.trim() == "Price"))
+        .unwrap_or(4);
+
     // --- Menu table: rows starting at index 0, stop when col A blank ---
     let mut menu: Vec<MenuRow> = Vec::new();
     let mut i = 0;
@@ -67,7 +76,7 @@ pub fn parse_tab(vr: &ValueRange) -> Result<ParsedTab, ParseError> {
         let a = cell(&rows[i], 0);
         if a.is_empty() { break; }
         if a == "Menu" { i += 1; continue; }
-        let price_str = cell(&rows[i], 4);
+        let price_str = cell(&rows[i], price_col);
         let price: i64 = price_str.parse().unwrap_or(0);
         if price > 0 {
             menu.push(MenuRow { menu_name: a.to_string(), price });
@@ -186,6 +195,25 @@ mod tests {
             ParsedOrderItem { menu_name: "มัทฉะเลเยอร์".into(), quantity: 2 }
         ]);
         assert_eq!(p.orders[1].delivery_location.as_deref(), Some("Pilates Timetable"));
+    }
+
+    #[test]
+    fn price_column_located_by_header_when_table_is_wider() {
+        // Newer tabs (e.g. Order_35) widen the menu table with computed amount
+        // columns, so "Price" sits at col F (idx 5), not col E. Layout taken from
+        // the real sheet: A=Menu, C=Total, D=net, F=Price, G/I=amounts.
+        let vr = vr(vec![
+            vec!["Menu", "", "Total", "", "", "Price", "Amount", "", "Total"],
+            vec!["Carrot Cranberry", "", "", "-8", "", "260", "2080", "", "2080"],
+            vec!["เค้กโคตรเผือก box", "", "16", "0", "", "149", "2384", "", "2384"],
+            vec![""],
+            vec!["ช่องทาง", "ลูกค้า", "Carrot Cran", "เค้กโคตรเผือก box", "สถานที่ส่ง", "Note"],
+            vec!["Line@", "K.Pangzyy", "1", "1", "home", "SUN"],
+        ]);
+        let p = parse_tab(&vr).unwrap();
+        assert_eq!(p.menu.len(), 2);
+        assert_eq!(p.menu[0], MenuRow { menu_name: "Carrot Cranberry".into(), price: 260 });
+        assert_eq!(p.menu[1], MenuRow { menu_name: "เค้กโคตรเผือก box".into(), price: 149 });
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,12 +10,28 @@ use tokio::sync::RwLock;
 pub struct AppState {
     pub db: SqlitePool,
     pub app_data_dir: PathBuf,
+    config: RwLock<AppConfig>,
     sheets: RwLock<Option<Arc<dyn SheetsClient>>>,
 }
 
 impl AppState {
     pub async fn new(app_data_dir: PathBuf, db: SqlitePool) -> Self {
-        Self { db, app_data_dir, sheets: RwLock::new(None) }
+        let config = crate::config::load_or_init(&app_data_dir);
+        Self { db, app_data_dir, config: RwLock::new(config), sheets: RwLock::new(None) }
+    }
+
+    /// The in-process source of truth for config. Commands that operate on
+    /// persisted state read this instead of taking config as an argument.
+    pub async fn config(&self) -> AppConfig {
+        self.config.read().await.clone()
+    }
+
+    /// Replace the live config (after `save_config` persists it). A changed
+    /// service-account path or spreadsheet id must rebuild the cached Sheets
+    /// client, so we drop it here.
+    pub async fn set_config(&self, cfg: AppConfig) {
+        *self.config.write().await = cfg;
+        self.invalidate_sheets_client().await;
     }
 
     /// Build (or rebuild) a SheetsClient for the given service-account path.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,8 +51,8 @@ function App() {
           </div>
         )}
         <div className="flex-1 overflow-hidden">
-          {activeTab === 'pos' && <POSPage appConfig={config} />}
-          {activeTab === 'orders' && <OrdersPage appConfig={config} />}
+          {activeTab === 'pos' && <POSPage />}
+          {activeTab === 'orders' && <OrdersPage />}
           {activeTab === 'sync' && <SyncPage appConfig={config} />}
           {activeTab === 'settings' && (
             <SettingsPage appConfig={config} onConfigSaved={handleConfigSaved} />

--- a/src/components/PaymentDialog.tsx
+++ b/src/components/PaymentDialog.tsx
@@ -3,7 +3,7 @@ import { Printer } from 'lucide-react';
 import { useCartStore, type DiscountType } from '../stores/cart';
 import NumPad from './NumPad';
 import { printer as tauriPrinter } from '../lib/tauri';
-import type { AppConfig, PrinterConfig, ReceiptData } from '../lib/types';
+import type { ReceiptData } from '../lib/types';
 import { Button } from './ui/button';
 import { Label } from './ui/label';
 import {
@@ -18,10 +18,9 @@ import { cn } from '../lib/cn';
 
 interface PaymentDialogProps {
   onClose: () => void;
-  appConfig: AppConfig | null;
 }
 
-export default function PaymentDialog({ onClose, appConfig }: PaymentDialogProps) {
+export default function PaymentDialog({ onClose }: PaymentDialogProps) {
   const items = useCartStore((s) => s.items);
   const customerName = useCartStore((s) => s.customerName);
   const discountType = useCartStore((s) => s.discountType);
@@ -44,10 +43,6 @@ export default function PaymentDialog({ onClose, appConfig }: PaymentDialogProps
   const total = getTotal();
 
   const handlePrint = async () => {
-    if (!appConfig) {
-      setError('Config not loaded');
-      return;
-    }
     if (items.length === 0) {
       setError('Cart is empty');
       return;
@@ -68,19 +63,7 @@ export default function PaymentDialog({ onClose, appConfig }: PaymentDialogProps
         discount: discountValue,
         deliveryFee,
       };
-      const printerConfig: PrinterConfig = {
-        ip: appConfig.printerIp,
-        paperWidth: appConfig.paperWidth,
-        shopName: appConfig.shopName,
-        shopPhone: appConfig.shopPhone,
-        shopLine: appConfig.shopLine,
-        qrText: 'Scan to Pay',
-        qrCodeType: appConfig.promptpayType,
-        qrCodeValue: appConfig.promptpayValue,
-        thankYouMessage: appConfig.thankYouMessage,
-      };
-
-      await tauriPrinter.printReceipt(receiptData, printerConfig);
+      await tauriPrinter.printReceipt(receiptData);
       clear();
       onClose();
     } catch (err) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -8,7 +8,6 @@ import type {
   OrderListRow,
   ProductLite,
   ReceiptData,
-  PrinterConfig,
   SyncMappings,
   SyncPreview,
   SyncResult,
@@ -22,17 +21,17 @@ export const appConfig = {
 export const printer = {
   test: (ip: string) => invoke<string>('test_printer', { ip }),
   checkStatus: (ip: string) => invoke<boolean>('check_printer_status', { ip }),
-  printReceipt: (receipt: ReceiptData, config: PrinterConfig) =>
-    invoke<string>('print_receipt', { receipt, config }),
+  printReceipt: (receipt: ReceiptData) =>
+    invoke<string>('print_receipt', { receipt }),
 };
 
 export const sheets = {
   testConnection: (config: AppConfig) =>
     invoke<{ name: string }[]>('test_sheets_connection', { config }),
-  syncWeek: (config: AppConfig, tab: string) =>
-    invoke<SyncPreview>('sync_week', { config, tab }),
-  applySync: (config: AppConfig, tab: string, mappings: SyncMappings) =>
-    invoke<SyncResult>('apply_sync', { config, tab, mappings }),
+  syncWeek: (tab: string) =>
+    invoke<SyncPreview>('sync_week', { tab }),
+  applySync: (tab: string, mappings: SyncMappings) =>
+    invoke<SyncResult>('apply_sync', { tab, mappings }),
   ignoreMenu: (tab: string, alias: string, ignore = true) =>
     invoke<void>('ignore_sync_menu', { tab, alias, ignore }),
   ignoreRow: (tab: string, sourceRow: number, ignore = true) =>
@@ -54,8 +53,8 @@ export const ordersApi = {
       limit: opts.limit ?? 200,
     }),
   get: (id: string) => invoke<OrderDetail | null>('get_order', { id }),
-  print: (config: AppConfig, id: string) =>
-    invoke<string>('print_order', { config, id }),
+  print: (id: string) =>
+    invoke<string>('print_order', { id }),
   update: (id: string, payload: OrderEditPayload) =>
     invoke<void>('update_order', { id, payload }),
   delete: (id: string) => invoke<void>('delete_order', { id }),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -190,18 +190,6 @@ export interface ReceiptData {
   deliveryFee: number;
 }
 
-export interface PrinterConfig {
-  ip: string;
-  paperWidth: number;
-  shopName: string;
-  shopPhone: string;
-  shopLine: string;
-  qrText: string;
-  qrCodeType: string;
-  qrCodeValue: string;
-  thankYouMessage: string;
-}
-
 // === POSPage cart ===
 
 export interface CartItem {

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -11,7 +11,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { ordersApi } from '../lib/tauri';
-import type { AppConfig, OrderDetail, OrderListRow } from '../lib/types';
+import type { OrderDetail, OrderListRow } from '../lib/types';
 import { Button } from '../components/ui/button';
 import { Checkbox } from '../components/ui/checkbox';
 import { Label } from '../components/ui/label';
@@ -35,13 +35,9 @@ import {
 } from '../components/ui/dialog';
 import { cn } from '../lib/cn';
 
-interface OrdersPageProps {
-  appConfig: AppConfig | null;
-}
-
 const ALL_TABS = '__all__';
 
-export default function OrdersPage({ appConfig }: OrdersPageProps) {
+export default function OrdersPage() {
   const [orders, setOrders] = useState<OrderListRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [filterTab, setFilterTab] = useState<string>(ALL_TABS);
@@ -165,10 +161,9 @@ export default function OrdersPage({ appConfig }: OrdersPageProps) {
   };
 
   const handlePrint = async (row: OrderListRow) => {
-    if (!appConfig) return;
     setPrintingId(row.id);
     try {
-      await ordersApi.print(appConfig, row.id);
+      await ordersApi.print(row.id);
       setDetails((prev) => {
         const next = { ...prev };
         delete next[row.id];

--- a/src/pages/POSPage.tsx
+++ b/src/pages/POSPage.tsx
@@ -1,16 +1,12 @@
 import { useEffect, useState } from 'react';
-import type { ProductLite, AppConfig } from '../lib/types';
+import type { ProductLite } from '../lib/types';
 import { catalog } from '../lib/tauri';
 import { useCartStore } from '../stores/cart';
 import ProductGrid from '../components/ProductGrid';
 import Cart from '../components/Cart';
 import PaymentDialog from '../components/PaymentDialog';
 
-interface POSPageProps {
-  appConfig: AppConfig | null;
-}
-
-export default function POSPage({ appConfig }: POSPageProps) {
+export default function POSPage() {
   const [products, setProducts] = useState<ProductLite[]>([]);
   const [loading, setLoading] = useState(true);
   const [showPayment, setShowPayment] = useState(false);
@@ -35,7 +31,7 @@ export default function POSPage({ appConfig }: POSPageProps) {
         <Cart onCharge={() => setShowPayment(true)} />
       </div>
       {showPayment && (
-        <PaymentDialog onClose={() => setShowPayment(false)} appConfig={appConfig} />
+        <PaymentDialog onClose={() => setShowPayment(false)} />
       )}
     </div>
   );

--- a/src/pages/SyncPage.tsx
+++ b/src/pages/SyncPage.tsx
@@ -81,7 +81,7 @@ export default function SyncPage({ appConfig }: SyncPageProps) {
     setMessage('');
     setPreview(null);
     try {
-      const p = await sheets.syncWeek(appConfig, selectedTab);
+      const p = await sheets.syncWeek(selectedTab);
       setPreview(p);
       if (p.unknownMenus.length === 0 && p.unknownCustomers.length === 0) {
         await doApply({ menu: [], customer: [] }, p);
@@ -98,7 +98,7 @@ export default function SyncPage({ appConfig }: SyncPageProps) {
     setApplying(true);
     setError('');
     try {
-      const res: SyncResult = await sheets.applySync(appConfig, p.tab, mappings);
+      const res: SyncResult = await sheets.applySync(p.tab, mappings);
       setMessage(
         `Synced ${p.tab}: +${res.rowsAdded} new · ~${res.rowsUpdated} updated · −${res.rowsSoftDeleted} removed`,
       );


### PR DESCRIPTION
## Summary

Three pieces of work from an architecture pass plus a follow-on bug fix.

### 1. Ambient config (refactor)
`AppState` now owns the live `AppConfig` (loaded once at startup via `config::load_or_init`). `sync_week`, `apply_sync`, `print_order`, and `print_receipt` read `state.config()` instead of taking config as an argument — config no longer round-trips JS→Rust on every call. The "test what I typed" commands (`test_sheets_connection`, `test_printer`) still take explicit input since they validate unsaved form values. `save_config` now replaces the live config **and** drops the cached Sheets client, so a changed service-account path / spreadsheet id takes effect. `PrinterConfig` assembly for both print paths consolidates into `PrinterConfig::from(&AppConfig)`. Frontend drops the now-unused `appConfig` props (POS/Orders) and the orphaned `PrinterConfig` type.

### 2. Order-view behind the orders module (refactor)
`orders::list_view` / `orders::get_view` now own all order-read SQL (customer name, item summary, item lines, merge resolution). The merge-resolution query that was duplicated across `list_orders` and `get_order` collapses into one `merge_info` helper. Command handlers are now thin one-liners with no `sqlx`.

### 3. Menu price-column fix (bug)
Newer order tabs widen the menu table with computed amount columns, pushing the `Price` header past column E. The parser hardcoded price at index 4, so every menu row read a blank cell → `Menu table appears empty`. Now the price column is resolved from the `Menu` header row by its `Price` label, falling back to index 4 for older tabs.

### 4. ADR-0001
Records deferring Rust→TS IPC codegen at current scale, with a revisit tripwire.

### Docs
CLAUDE.md rewritten for the current Tauri/React/Rust stack (the old one described a defunct Python/Eel app); README gains a Development section.

## Testing
- `cargo test` — 57 passing (incl. new view + price-column regression tests)
- `npm test` — 21 passing
- `tsc --noEmit` — clean
- Manually verified the `27-28/06/26` sync and order reassignment in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)